### PR TITLE
docs: make daily refresh track the project-instruction baseline

### DIFF
--- a/docs/cloud-automation.md
+++ b/docs/cloud-automation.md
@@ -38,10 +38,18 @@ daily schedule
 -> review and merge
 ```
 
-The Claude Routine never commits to `main`. It always opens a pull request from a
-`claude/`-prefixed branch (for example `claude/daily-doc-refresh-YYYY-MM-DD`) so
-every change — including project-instruction baseline drift — is reviewed before
-merge.
+The Claude Routine never commits to `main`. It opens a pull request from a
+branch instead, so every change — including project-instruction baseline drift —
+is reviewed before merge.
+
+**Branch prefix policy.** A configurable custom branch prefix is not documented
+for Claude Routines. By default the routine can only push `claude/`-prefixed
+branches (for example `claude/daily-doc-refresh-YYYY-MM-DD`). To let it push an
+existing branch or a different prefix — such as an org-policy prefix like
+`aldegad/` — enable **Allow unrestricted branch pushes** in that repository's
+routine Permissions. Local agents on this machine are a separate context: the
+local `cc-guard` blocks `claude/` and `codex/` branch names, so do local PR work
+from an `aldegad/`-prefixed branch.
 
 ## Alternative: Codex App Automations
 

--- a/docs/cloud-automation.md
+++ b/docs/cloud-automation.md
@@ -44,12 +44,9 @@ is reviewed before merge.
 
 **Branch prefix policy.** A configurable custom branch prefix is not documented
 for Claude Routines. By default the routine can only push `claude/`-prefixed
-branches (for example `claude/daily-doc-refresh-YYYY-MM-DD`). To let it push an
-existing branch or a different prefix — such as an org-policy prefix like
-`aldegad/` — enable **Allow unrestricted branch pushes** in that repository's
-routine Permissions. Local agents on this machine are a separate context: the
-local `cc-guard` blocks `claude/` and `codex/` branch names, so do local PR work
-from an `aldegad/`-prefixed branch.
+branches (for example `claude/daily-doc-refresh-YYYY-MM-DD`). To push a different
+branch or prefix, enable **Allow unrestricted branch pushes** in that
+repository's routine Permissions.
 
 ## Alternative: Codex App Automations
 

--- a/docs/cloud-automation.md
+++ b/docs/cloud-automation.md
@@ -1,6 +1,6 @@
 # Cloud Automation
 
-Last reviewed: 2026-05-27
+Last reviewed: 2026-06-03
 
 Keep this repo's compatibility docs current by running a daily agent that reads
 `docs/official-sources.json`, fetches the official vendor URLs, and opens a pull
@@ -29,11 +29,19 @@ daily schedule
 -> read docs/official-sources.json
 -> validate official source reachability
 -> fetch only the official vendor URLs
+-> re-verify project-instruction file claims (kind=project-instructions)
 -> update repo docs only when official evidence changed
+-> reconcile Project Instruction Files baseline on drift
+   (SKILL.md, compatibility-matrix.md, plugin-packaging.md)
 -> run node scripts/check-official-sources.mjs --write-report
 -> open a PR from a claude/-prefixed branch (never push to main)
 -> review and merge
 ```
+
+The Claude Routine never commits to `main`. It always opens a pull request from a
+`claude/`-prefixed branch (for example `claude/daily-doc-refresh-YYYY-MM-DD`) so
+every change — including project-instruction baseline drift — is reviewed before
+merge.
 
 ## Alternative: Codex App Automations
 

--- a/prompts/daily-official-doc-update.md
+++ b/prompts/daily-official-doc-update.md
@@ -14,9 +14,23 @@ summary rather than substituting another source.
 
 **WHAT TO CHECK** across these agents/products: OpenAI Codex, Claude / Claude
 Code, Grok/xAI, Gemini / Gemini CLI, Cursor, Hermes Agent, Kuma Studio. For each,
-review: supported-agent docs, plugin/extension docs, compatibility matrix, and
-Kuma Studio pattern docs. If an official doc confirms a feature difference or
-that something is unavailable, state that explicitly in the docs.
+review: supported-agent docs, plugin/extension docs, project-instruction /
+context-file docs, compatibility matrix, and Kuma Studio pattern docs. If an
+official doc confirms a feature difference or that something is unavailable, state
+that explicitly in the docs.
+
+**PROJECT INSTRUCTION FILES — do not skip this category.** It is not skills,
+hooks, or plugin packaging, so it is easy to miss. Every source in
+`docs/official-sources.json` with `"kind": "project-instructions"` — and any
+instruction-file claims such as `AGENTS.override.md`, `AGENTS.md`, `CLAUDE.md`,
+`GEMINI.md`, `.hermes.md` / `HERMES.md`, or `.cursor/rules` — MUST be fetched and
+re-verified every run. If the official docs changed which filenames a runtime
+reads, their priority order, or which file is project vs. global identity, treat
+the **Project Instruction Files** baseline as drifted and update all three
+mirrors so they stay consistent: the `## Project Instruction Files` sections in
+`SKILL.md` and `docs/plugin-packaging.md`, plus the **Project instructions**
+column of `docs/compatibility-matrix.md`. Do not infer a filename for one runtime
+from another — cite the runtime's own official doc.
 
 **IF THERE ARE CHANGES:** make small, reviewable edits to the repo docs. Cite the
 official source URL in the docs or in the PR body. Run

--- a/scripts/check-official-sources.mjs
+++ b/scripts/check-official-sources.mjs
@@ -54,6 +54,25 @@ for (const source of manifest.sources ?? []) {
   assertArray(source.claims, `${source.id}.claims`);
 }
 
+// Guard the Project Instruction Files baseline so a future edit cannot silently
+// drop the category that the daily refresh must keep verifying. Codex and Claude
+// Code are the anchor runtimes with dedicated official memory/AGENTS.md pages.
+const projectInstructionAgents = new Set(
+  (manifest.sources ?? [])
+    .filter((source) => source.kind === "project-instructions")
+    .map((source) => source.agent)
+);
+if (projectInstructionAgents.size === 0) {
+  fail(
+    "no source has kind=project-instructions; the Project Instruction Files baseline must stay covered"
+  );
+}
+for (const requiredAgent of ["codex", "claude-code"]) {
+  if (!projectInstructionAgents.has(requiredAgent)) {
+    fail(`missing kind=project-instructions source for ${requiredAgent}`);
+  }
+}
+
 if (!skipNetwork) {
   for (const source of manifest.sources ?? []) {
     const started = Date.now();


### PR DESCRIPTION
## Why

Commit `051ebdf` added a **Project Instruction Files** baseline (the `## Project Instruction Files` sections in `SKILL.md` and `docs/plugin-packaging.md`, the **Project instructions** column in `docs/compatibility-matrix.md`, and `kind=project-instructions` sources in `docs/official-sources.json`).

But the daily official-docs refresh never told the agent to *verify* that category, so it could silently drift out of date. This PR closes that gap.

## What

- **`prompts/daily-official-doc-update.md`** — adds an explicit "PROJECT INSTRUCTION FILES — do not skip" block. Every `kind=project-instructions` source and instruction-file claim (`AGENTS.override.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.hermes.md`/`HERMES.md`, `.cursor/rules`) must be re-fetched each run, and the three doc mirrors are named as drift targets. Also adds project-instruction/context-file docs to the per-agent review list.
- **`docs/cloud-automation.md`** — adds the instruction-file verify + baseline-reconcile steps to the recommended daily flow, bumps `Last reviewed` to 2026-06-03, and documents the routine branch-prefix policy: the default is a `claude/`-prefixed branch, and pushing a different branch or prefix needs **Allow unrestricted branch pushes** in the repo's routine Permissions.
- **`scripts/check-official-sources.mjs`** — adds a structural guard that fails loudly if the `kind=project-instructions` baseline (with `codex` + `claude-code` anchors) is ever dropped, so the category can't disappear unnoticed.

## Verification

- `node scripts/check-official-sources.mjs --skip-network` → pass (24 sources).
- `node scripts/check-official-sources.mjs --write-report` → pass, all 24 sources HTTP 200.
- Negative test: removing the `project-instructions` sources makes the new guard fail loudly (3 errors) as intended.
