### PR TITLE
docs: add Session Resume capability across the four runtimes (doc-first)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-hook-authoring
-description: 'Use for agent extension and plugin-like package authoring across Codex, Claude, Grok, and Hermes: skills, hooks, plugin packaging, symlink installs, guardrails, and runtime drift.'
+description: 'Use for agent extension and plugin-like package authoring across Codex, Claude, Grok, and Hermes: skills, hooks, plugin packaging, session resume, symlink installs, guardrails, and runtime drift.'
 ---
 
 # Skill Hook Authoring
@@ -30,6 +30,15 @@ Keep the current detailed truth in `docs/compatibility-matrix.md` and `docs/plug
 | Hermes Agent | Skills and skill preloading are documented | Hook parity is not documented in the cited source set | MCP/toolsets are documented; plugin packaging parity is not documented here |
 
 When a runtime capability is not documented, write `not documented` or `unknown` and require live verification before shipping behavior that depends on it.
+
+## Session Resume
+
+Same-platform resume (continue the *same* conversation on the *same* engine, by session id) is officially documented for all four worker runtimes. Per-engine resume invocation, session store, and id form live in `docs/compatibility-matrix.md` → **Session Resume**. The working model:
+
+- The minimum to continue is the **resume locator** (session/thread id) plus the engine's resume invocation: Claude `claude --resume <id>`, Codex CLI `codex resume <id>` (desktop app-server: the `thread/resume` method with the recorded `thread.id`), Grok `grok -r/--resume <id>`, Hermes `hermes --resume <id>`.
+- Capture the locator **before the worker exits**, keyed by `cwd` (the most stable signal every engine exposes). Session stores differ — Claude/Codex/Grok keep per-session transcript/rollout files; **Hermes keeps history in SQLite `~/.hermes/state.db`**, so a file scan of `~/.hermes/sessions/` (which holds only API error dumps) finds nothing resumable.
+- **Cross-engine moves** (resume one engine's session under a *different* engine) are a separate, harder problem and out of scope here — keep them off the same-platform path.
+- When a runtime does not document resume, record `not documented` and require live verification before shipping.
 
 ## Project Instruction Files
 

--- a/docs/cloud-automation.md
+++ b/docs/cloud-automation.md
@@ -15,8 +15,8 @@ run continues when your laptop is closed.
 1. In Claude Code, run `/schedule` (or open <https://claude.ai/code/routines>).
 2. Point the routine's git source at this repository.
 3. Use the daily prompt in `prompts/daily-official-doc-update.md`.
-4. Schedule it once per day. The routine opens a PR from a `claude/`-prefixed
-   branch; you review and merge.
+4. Schedule it once per day. The routine opens a PR from an `aldegad/`-prefixed
+   branch (see **Branch prefix policy** below); you review and merge.
 
 Do not set `ANTHROPIC_API_KEY` in the routine environment — Routines bill
 against the subscription usage pool, and a present API key suppresses the
@@ -34,7 +34,7 @@ daily schedule
 -> reconcile Project Instruction Files baseline on drift
    (SKILL.md, compatibility-matrix.md, plugin-packaging.md)
 -> run node scripts/check-official-sources.mjs --write-report
--> open a PR from a claude/-prefixed branch (never push to main)
+-> open a PR from an aldegad/-prefixed branch (never push to main)
 -> review and merge
 ```
 
@@ -42,11 +42,13 @@ The Claude Routine never commits to `main`. It opens a pull request from a
 branch instead, so every change — including project-instruction baseline drift —
 is reviewed before merge.
 
-**Branch prefix policy.** A configurable custom branch prefix is not documented
-for Claude Routines. By default the routine can only push `claude/`-prefixed
-branches (for example `claude/daily-doc-refresh-YYYY-MM-DD`). To push a different
-branch or prefix, enable **Allow unrestricted branch pushes** in that
-repository's routine Permissions.
+**Branch prefix policy.** This repo's local `cc-guard` hook rejects branch names
+containing `claude` or `codex` and requires an `aldegad/`-prefixed branch (see the
+existing `aldegad/...` branches). Claude Routines, however, default to pushing
+`claude/`-prefixed branches, and a configurable custom prefix is not documented
+for them. To stay consistent with the local guard, enable **Allow unrestricted
+branch pushes** in that repository's routine Permissions and push an
+`aldegad/`-prefixed branch (for example `aldegad/daily-doc-refresh-YYYY-MM-DD`).
 
 ## Alternative: Codex App Automations
 

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -14,6 +14,25 @@ This matrix records only official documentation claims from `docs/official-sourc
 | Cursor CLI | Official docs describe CLI agent usage with Agent, Plan, and Ask modes. (Docs moved from docs.cursor.com to cursor.com/docs as of 2026-05-27.) | Hook parity is not documented in the cited source set. | MCP auto-detection via `mcp.json`; plugin packaging parity with Codex is not documented. | Official docs confirm `.cursor/rules`, project-root `AGENTS.md`, and project-root `CLAUDE.md` support. Worktree support via `--worktree` flag is also documented. | External scheduler or CI unless official Cursor automation docs are added. |
 | Kuma Studio | Public repo methodology uses repo SSoT, dispatch delivery, plan close gates, and visible worker surfaces. | Hooks are guardrails and must fail loudly. | Kuma skills live in canonical repo paths and may be installed by symlink or generated config. | `AGENTS.md` and `CLAUDE.md` are parallel SSoT for shared rules. | Use project-specific dispatch, plan, and server workflows; public docs should not depend on private vault content. |
 
+## Session Resume
+
+Same-platform resume (continue an existing conversation on the same engine, by session id) is officially documented for all four primary worker runtimes. Cross-engine moves are a separate concern and out of scope here.
+
+| Platform | Resume invocation | Session store | Session id form | Source (verified 2026-06-06) |
+|---|---|---|---|---|
+| OpenAI Codex (CLI) | `codex resume <SESSION_ID>` or `codex resume --last` (interactive); `codex exec resume [SESSION_ID]` / `--last` (non-interactive). `--all` ignores the cwd filter. | Rollout transcripts under `CODEX_HOME`, e.g. `~/.codex/sessions/` (`rollout-*.jsonl`) plus `~/.codex/history.jsonl`. | session id copied from the picker, `/status`, or the session files. | https://developers.openai.com/codex/cli/reference |
+| OpenAI Codex (app-server) | Call the `thread/resume` method with the recorded `thread.id` over the stdio app-server API. Related: `thread/start`, `thread/fork`, `thread/read`. | Thread data is persisted as JSONL rollout log files (exact directory not explicitly stated in the cited doc; rollout naming matches `~/.codex/sessions/`). | `threadId`; a root thread's id is its `sessionId` (forks keep the root's session id). | https://developers.openai.com/codex/app-server |
+| Claude Code | `claude --resume <session-id>` (or `--continue` / `-c`, or `/resume`). Reopens under the same session id and appends. `--fork-session` copies into a new id. | Local transcript files written continuously (`~/.claude/projects/<cwd-hash>/<id>.jsonl`). | session id (same id reused on resume). | https://code.claude.com/docs/en/sessions |
+| Grok / xAI | `grok -r, --resume <ID>` resumes by session id; `grok -s, --session-id <ID>` creates or resumes a named headless session. | Local session history under `~/.grok/` (live sessions enumerated in `~/.grok/active_sessions.json` as `[{session_id, pid, cwd, opened_at}]`). | `session_id`. | https://docs.x.ai (Headless & Scripting) |
+| Hermes Agent | `hermes --resume <session_id>` / `-r <session_id>`; `hermes --continue` / `-c` resumes the most recent; resume by title also supported. Restores full conversation. | **SQLite `~/.hermes/state.db`** (conversation history, lineage, FTS). NOT the API error dumps under `~/.hermes/sessions/` (`request_dump_*.json`), which are unrelated. | `YYYYMMDD_HHMMSS_<suffix>` (e.g. `20260225_143052_a1b2c3`). | https://hermes-agent.nousresearch.com/docs/user-guide/cli/ |
+
+Notes for implementers:
+
+- The resume **locator** (session/thread id) plus the engine's resume invocation is the minimum needed to continue same-platform. Capture the locator before the worker exits, keyed by cwd (the most stable cross-engine signal exposed here).
+- Codex workers launched through the desktop **app-server** (`codex app-server --listen stdio://`) resume via `thread/resume`, not a CLI flag; if the rollout JSONL lands under `~/.codex/sessions/`, the CLI `codex resume <id>` path may also apply. Verify the live rollout path before relying on either.
+- Hermes resume reads from `state.db` (SQLite), so a file-scan over `~/.hermes/sessions/` will not find resumable state — query the db (or the displayed "Resume this session with: hermes --resume <id>" line) instead.
+- When a runtime does not document a resume capability, record `not documented` and require live verification before shipping.
+
 ## Update Rule
 
 When official docs change:

--- a/docs/official-sources.json
+++ b/docs/official-sources.json
@@ -192,6 +192,41 @@
       "kind": "notifications",
       "url": "https://docs.github.com/en/subscriptions-and-notifications/get-started/configuring-notifications",
       "claims": ["email notifications", "review requests", "watching", "participating"]
+    },
+    {
+      "id": "openai-codex-cli-reference",
+      "agent": "codex",
+      "kind": "session-resume",
+      "url": "https://developers.openai.com/codex/cli/reference",
+      "claims": ["codex resume", "codex resume --last", "codex exec resume", "--all", "~/.codex/sessions", "rollout jsonl", "~/.codex/history.jsonl"]
+    },
+    {
+      "id": "openai-codex-app-server",
+      "agent": "codex",
+      "kind": "session-resume",
+      "url": "https://developers.openai.com/codex/app-server",
+      "claims": ["thread/start", "thread/resume", "thread/fork", "thread/read", "threadId", "sessionId", "rollout jsonl"]
+    },
+    {
+      "id": "anthropic-claude-sessions",
+      "agent": "claude-code",
+      "kind": "session-resume",
+      "url": "https://code.claude.com/docs/en/sessions",
+      "claims": ["--resume", "--continue", "-c", "/resume", "--fork-session", "same session id reused", "local transcript files"]
+    },
+    {
+      "id": "xai-grok-headless-scripting",
+      "agent": "grok",
+      "kind": "session-resume",
+      "url": "https://docs.x.ai/build/cli/headless-scripting",
+      "claims": ["-r --resume", "-s --session-id", "~/.grok", "session_id"]
+    },
+    {
+      "id": "nous-hermes-cli-resume",
+      "agent": "hermes-agent",
+      "kind": "session-resume",
+      "url": "https://hermes-agent.nousresearch.com/docs/user-guide/cli/",
+      "claims": ["--resume", "-r", "--continue", "-c", "resume by title", "~/.hermes/state.db sqlite", "session id YYYYMMDD_HHMMSS_suffix"]
     }
   ]
 }

--- a/prompts/daily-official-doc-update.md
+++ b/prompts/daily-official-doc-update.md
@@ -15,9 +15,9 @@ summary rather than substituting another source.
 **WHAT TO CHECK** across these agents/products: OpenAI Codex, Claude / Claude
 Code, Grok/xAI, Gemini / Gemini CLI, Cursor, Hermes Agent, Kuma Studio. For each,
 review: supported-agent docs, plugin/extension docs, project-instruction /
-context-file docs, compatibility matrix, and Kuma Studio pattern docs. If an
-official doc confirms a feature difference or that something is unavailable, state
-that explicitly in the docs.
+context-file docs, session-resume docs, compatibility matrix, and Kuma Studio
+pattern docs. If an official doc confirms a feature difference or that something
+is unavailable, state that explicitly in the docs.
 
 **PROJECT INSTRUCTION FILES — do not skip this category.** It is not skills,
 hooks, or plugin packaging, so it is easy to miss. Every source in
@@ -32,10 +32,23 @@ mirrors so they stay consistent: the `## Project Instruction Files` sections in
 column of `docs/compatibility-matrix.md`. Do not infer a filename for one runtime
 from another — cite the runtime's own official doc.
 
+**SESSION RESUME — do not skip this category.** Like project-instruction files,
+it is a capability domain that is easy to miss because it is not skills, hooks,
+or plugin packaging. Every source in `docs/official-sources.json` with
+`"kind": "session-resume"` MUST be fetched and re-verified every run. For each
+runtime confirm the resume invocation (e.g. `--resume`/`resume`/`thread/resume`),
+the session-store location, and the session-id form. If the official docs changed
+any of these, treat the **Session Resume** baseline as drifted and update both
+mirrors so they stay consistent: the `## Session Resume` section of `SKILL.md` and
+the `## Session Resume` table in `docs/compatibility-matrix.md`. Cite the
+runtime's own official doc; do not infer one runtime's resume mechanism from
+another.
+
 **IF THERE ARE CHANGES:** make small, reviewable edits to the repo docs. Cite the
 official source URL in the docs or in the PR body. Run
 `node scripts/check-official-sources.mjs --write-report`. Do NOT push to main.
-Create a pull request from a `claude/`-prefixed branch.
+Create a pull request from an `aldegad/`-prefixed branch (the `cc-guard` hook
+rejects branch names containing `claude` or `codex`).
 
 **IF THERE ARE NO CHANGES:** do not modify any file. Leave a short no-op summary
 only.


### PR DESCRIPTION
## Summary

Adds session-resume coverage to the skill. It previously documented skills, hooks, plugins, and project-instruction files but had **no resume/session info**, so same-platform resume mechanisms were undocumented.

All facts are from official vendor docs (per the repo's source-only policy):

- `docs/compatibility-matrix.md` — new **Session Resume** table for Codex (CLI + app-server), Claude Code, Grok, and Hermes: resume invocation, session store, id form, source URL.
- `SKILL.md` — `session resume` added to the description + a `## Session Resume` working-model section (locator + resume invocation, capture-before-exit keyed by cwd).
- `docs/official-sources.json` — 5 sources with `kind: "session-resume"` (hosts already in `allowedHosts`).
- `prompts/daily-official-doc-update.md` — Session Resume added to WHAT TO CHECK + a do-not-skip emphasis block so the daily run keeps it current.

### Tidy-up

Branch-prefix references in the daily prompt and `cloud-automation.md` corrected from `claude/` to `aldegad/`, matching the local `cc-guard` hook (which rejects branch names containing `claude`/`codex`). Noted that Claude Routines default to `claude/` and need **Allow unrestricted branch pushes** to use `aldegad/`.

### Doc-first corrections worth noting

- **Hermes supports resume** (`hermes --resume <id>`); state lives in SQLite `~/.hermes/state.db`, *not* the `~/.hermes/sessions/` API error dumps.
- The **Codex desktop app-server** resumes via the `thread/resume` method (with the recorded `thread.id`), not a CLI flag.

`node scripts/check-official-sources.mjs` passes (29 sources).

Sources: developers.openai.com/codex/cli/reference · developers.openai.com/codex/app-server · code.claude.com/docs/en/sessions · docs.x.ai (Headless & Scripting) · hermes-agent.nousresearch.com/docs/user-guide/cli/
