### PR TITLE
docs: reposition as cross-runtime interoperability wiki + billing domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ package manifest, so the **git tag plus this file are the version record**
 (the official Claude SKILL.md frontmatter documents only `name` and
 `description`, so the version is intentionally not stamped there).
 
+## v1.2 — 2026-06-09
+
+Repositioning release: the package is now framed as what it had already grown
+into — a cross-runtime interoperability wiki plus the methodology to manage it.
+
+### Changed
+
+- **Repositioned as a cross-runtime agent-platform interoperability wiki +
+  methodology.** `SKILL.md` and `README.md` now lead with the daily-refreshed
+  7-runtime compatibility wiki (Codex, Claude Code, Grok, Hermes, Antigravity
+  CLI, Cursor, Kuma Studio); the old "Four-Runtime Baseline" became "Runtime
+  Coverage" listing all seven. The skill `name` stays `skill-hook-authoring`
+  (install symlinks and the `cc-guard` hook depend on the id).
+
+### Added
+
+- **Billing capability domain.** New `kind: "billing"` sources in
+  `docs/official-sources.json`: Claude Code subscription vs. API billing, and the
+  **2026-06-15** change after which Agent SDK / `claude -p` (headless) usage no
+  longer counts toward the Claude plan. Mirrored as a Billing caveat in
+  `docs/cli-invocation.md` and a "Why not a local cron" block in
+  `docs/cloud-automation.md`; the daily refresh now re-verifies the billing
+  category.
+- **History-out-of-bodies rule** in `SKILL.md` Core Rules and the daily prompt:
+  changelog narrative lives in `CHANGELOG.md` + git tag, doc bodies state current
+  truth only (a `Last reviewed:` / `verified` stamp is the lone dated exception).
+
+### Fixed
+
+- `README.md` daily-refresh branch prefix corrected `claude/` → `aldegad/` (the
+  `cc-guard` hook rejects branch names containing `claude` or `codex`).
+
 ## v1.1 — 2026-06-06
 
 A large doc release adding two capability domains (CLI spawn and session resume),

--- a/README.md
+++ b/README.md
@@ -1,25 +1,32 @@
-# Skill Hook Authoring
+# Cross-Runtime Agent-Platform Interoperability
 
-Shared methodology for authoring agent skills, hooks, commands, extensions, plugins, and repo-owned guardrails without drifting between agent runtimes.
+Two things in one repo:
+
+1. **A compatibility wiki**, refreshed daily from official vendor docs, recording how today's agent runtimes — Codex, Claude Code, Grok, Hermes, Antigravity CLI, Cursor, and Kuma Studio — compare across skills, hooks, plugins/extensions, project-instruction files, CLI spawn (interactive vs headless), session resume, and billing.
+2. **A methodology** for interoperating and managing those runtimes: shipping one repo-owned source of truth (skills, hooks, commands, scripts, references, assets, MCP/app wiring, or runtime-specific plugin metadata) without drifting between agents.
+
+Every compatibility claim cites the vendor's own docs; where a runtime does not document a capability, the wiki records `not documented` rather than inferring parity.
 
 ## What This Repo Owns
 
-- `SKILL.md` is the skill entrypoint.
-- `docs/official-sources.json` is the source manifest for official vendor documentation.
-- `docs/compatibility-matrix.md` records what each agent officially supports.
-- `docs/plugin-packaging.md` explains how plugin or extension packaging differs by platform.
+- `SKILL.md` is the skill entrypoint and the authoring/interoperation methodology.
+- `docs/compatibility-matrix.md` is the cross-runtime comparison (includes the Session Resume table).
+- `docs/cli-invocation.md` records per-runtime CLI spawn (interactive vs headless) and resume syntax.
+- `docs/plugin-packaging.md` explains how plugin/extension packaging differs by platform.
+- `docs/official-sources.json` is the source manifest that the daily refresh re-verifies.
+- `docs/cloud-automation.md` explains the daily update automation and why it runs in the cloud, not locally.
 - `docs/kuma-studio-patterns.md` captures public Kuma Studio operating patterns.
-- `docs/cloud-automation.md` explains the daily update automation.
+- `CHANGELOG.md` plus the git tag are the version record. History stays here, not in the doc bodies.
 
-## Daily Official-Docs Update
+## Daily Wiki Refresh
 
-A daily agent keeps the compatibility docs current: it reads `docs/official-sources.json`, fetches the official vendor URLs, and opens a pull request when the evidence changed. It never pushes to `main`.
+A daily agent keeps the wiki current: it reads `docs/official-sources.json`, fetches the official vendor URLs, and opens a pull request when the evidence changed. It never pushes to `main`.
 
-The recommended path is **Claude Routines** — a scheduled Claude Code session that runs in Anthropic's cloud on a Claude subscription, with no API key and no GitHub Actions, and keeps running when your laptop is closed.
+The recommended path is **Claude Routines** — a scheduled Claude Code session that runs in Anthropic's cloud on a Claude subscription, with no API key and no GitHub Actions, and keeps running when your laptop is closed. Running the refresh **locally** via `claude -p` is discouraged: headless `claude -p` bills as per-token API usage (not the subscription), and from 2026-06-15 Agent SDK / `claude -p` usage no longer counts toward the Claude plan at all. See `docs/cloud-automation.md`.
 
 1. In Claude Code, run `/schedule` (or open <https://claude.ai/code/routines>).
 2. Point the routine at this repository and use the prompt in `prompts/daily-official-doc-update.md`.
-3. Schedule it once a day. It opens a PR from a `claude/`-prefixed branch; you review and merge.
+3. Schedule it once a day. It opens a PR from an `aldegad/`-prefixed branch (the `cc-guard` hook rejects `claude`/`codex` branch names); you review and merge.
 
 Codex users can run the same flow with a Codex App Automation instead. See `docs/cloud-automation.md` for both paths.
 
@@ -29,4 +36,4 @@ Codex users can run the same flow with a Codex App Automation instead. See `docs
 node scripts/check-official-sources.mjs --write-report
 ```
 
-The script validates source IDs, allowed official hosts, URL reachability, and the `SKILL.md` line budget.
+The script validates source IDs, allowed official hosts, URL reachability, the required source categories, and the `SKILL.md` line budget.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,11 +1,16 @@
 ---
 name: skill-hook-authoring
-description: 'Use for agent extension and plugin-like package authoring across Codex, Claude, Grok, and Hermes: skills, hooks, plugin packaging, CLI spawn and session resume, symlink installs, guardrails, and runtime drift.'
+description: 'Cross-runtime agent-platform interoperability wiki, refreshed daily from official vendor docs: how Codex, Claude Code, Grok, Hermes, Antigravity CLI, Cursor, and Kuma Studio compare across skills, hooks, plugins/extensions, project-instruction files, CLI spawn, session resume, and billing — plus the authoring rules to ship one source of truth without drifting between runtimes.'
 ---
 
-# Skill Hook Authoring
+# Cross-Runtime Agent-Platform Interoperability
 
-Create shared agent extension packages from one repo-owned source of truth. These packages may contain skills, hooks, commands, scripts, references, assets, MCP/app wiring, or runtime-specific plugin metadata.
+This package is two things at once:
+
+1. **A compatibility wiki**, refreshed daily from official vendor docs, recording how today's agent runtimes — Codex, Claude Code, Grok, Hermes, Antigravity CLI, Cursor, and Kuma Studio — compare across skills, hooks, plugins/extensions, project-instruction files, CLI spawn (interactive vs headless), session resume, and billing. Every claim cites the vendor's own docs; absent docs are recorded as `not documented`, never inferred.
+2. **A methodology** for *interoperating and managing* those runtimes: how to ship one repo-owned source of truth — skills, hooks, commands, scripts, references, assets, MCP/app wiring, or runtime-specific plugin metadata — without drifting between agents.
+
+The detailed comparison lives in `docs/` (start with `docs/compatibility-matrix.md`); the daily refresh keeps it current (`docs/cloud-automation.md`). The rest of this file is the authoring/interoperation methodology that turns that wiki into shippable, non-drifting packages.
 
 ## Taxonomy
 
@@ -18,9 +23,9 @@ Use these words precisely:
 
 If the task changes discovery, installation, trust, hook behavior, bundled scripts, or cross-runtime compatibility, treat it as **package authoring**, not just skill text editing.
 
-## Four-Runtime Baseline
+## Runtime Coverage
 
-Keep the current detailed truth in `docs/compatibility-matrix.md` and `docs/plugin-packaging.md`. This is the short working model:
+Seven runtimes are tracked. The detailed, source-cited truth lives in `docs/compatibility-matrix.md` and `docs/plugin-packaging.md`; this is the short working model:
 
 | Runtime | Skill surface | Hook surface | Plugin/package surface |
 |---|---|---|---|
@@ -28,6 +33,9 @@ Keep the current detailed truth in `docs/compatibility-matrix.md` and `docs/plug
 | Claude Code | `.claude/skills`, `.claude/commands`, skill frontmatter/settings | `.claude/settings.json` hooks | Marketplace/plugin settings exist; no cited Codex-style plugin package format |
 | Grok / xAI | Reusable skill folders | User, project, and plugin hook roots | Plugins can bundle skills, agents, hooks, MCP servers, and LSP servers |
 | Hermes Agent | Skills and skill preloading are documented | Hook parity is not documented in the cited source set | MCP/toolsets are documented; plugin packaging parity is not documented here |
+| Antigravity CLI (`agy`, was Gemini CLI) | `.agents/skills/` (global `~/.gemini/antigravity-cli/skills/`) | TUI `/hooks` browser; config format not verified in the cited render | Native plugins; MCP via standalone `mcp_config.json` |
+| Cursor CLI | reusable agent context; `.cursor/rules` | not documented in the cited source set | MCP auto-detection via `mcp.json`; Codex-style packaging not documented |
+| Kuma Studio | skills in canonical repo paths | guardrail hooks that must fail loudly | symlink or generated-config install |
 
 When a runtime capability is not documented, write `not documented` or `unknown` and require live verification before shipping behavior that depends on it.
 
@@ -88,6 +96,7 @@ For cross-agent repo rules, maintain the smallest set of files that each runtime
 - Hooks are guardrails, not silent fallback paths. They should block clearly, explain why, and require an explicit operator decision for dangerous actions.
 - Cross-agent guidance must be based on official vendor docs. If a platform does not document a feature, record it as `not documented` or `unknown`; do not infer parity from another agent.
 - **Make hook scripts executable (`chmod +x`) and give them a shebang.** Claude registers hooks as `command: "<abs-path> --args"` and runs them through `/bin/sh`, so a missing exec bit fails with `Permission denied` on *every* matching event (PreToolUse/Stop) in *every* session — one forgotten `chmod +x` silently breaks all agents at once. Codex registers as `node <path>` so it tolerates a missing bit, but always `chmod +x` for parity and **commit the mode** (git stores `100755`). (Trial-and-error 2026-05-26: a new guard hook shipped `644` → `Permission denied` spam across all live sessions until chmod'd.)
+- **Keep history out of doc bodies.** Changelog narrative — what was added/changed/removed and when — lives in `CHANGELOG.md` plus the git tag (the version SSoT), never accreting in `SKILL.md` or `docs/*` prose. A doc body states the **current** truth only; when a fact changes, replace it, don't append the old one. The one exception is a *verification* stamp (`Last reviewed: YYYY-MM-DD`, `verified YYYY-MM-DD`): that is provenance for a live claim, not history. This is what keeps a daily-refreshed wiki from turning into a changelog as it is re-verified.
 
 ## Recommended Layout
 

--- a/docs/cli-invocation.md
+++ b/docs/cli-invocation.md
@@ -61,6 +61,15 @@ the same idea, but they are reached differently:
 | Antigravity CLI | not documented — no `agy -p` one-shot in official docs | — | the TUI can pipe JSON status-line metadata to a shell script, but that is not a one-shot run | use the **Antigravity SDK** for programmatic/unattended runs; `--sandbox`, `--dangerously-skip-permissions` are launch overrides, not a headless mode |
 | Cursor CLI | `cursor-agent -p "<prompt>"` (`--print`) | print mode for scripts | `--output-format text\|json\|stream-json` (only with `--print`); `--stream-partial-output` | `--model`, `-f`/`--force` (`--yolo`), `--trust` (headless only) |
 
+> **Billing caveat (Claude Code).** Headless `claude -p` is *not* covered like an
+> interactive session: it bills as **per-token API usage** even when
+> authenticated via OAuth on a Pro/Max subscription with no `ANTHROPIC_API_KEY`
+> set, and **from 2026-06-15 Agent SDK / `claude -p` usage no longer counts
+> toward the Claude plan at all** — the subscription pool is reserved for
+> interactive use. For unattended/scheduled work prefer a cloud **Claude Routine**
+> (subscription-pool billing) over a local `claude -p` cron, and run `/status` to
+> confirm the active auth method. See `docs/cloud-automation.md`.
+
 ## C. Resume invocation (command syntax)
 
 Resume splits the same way: for the flag-based runtimes, the resume flag alone
@@ -144,3 +153,5 @@ Official (Google Developers Blog, 2026-05; antigravity.google docs):
 - Antigravity CLI conversations (`--continue`, `--conversation`, `/resume`) — <https://antigravity.google/docs/cli-conversations>
 - Antigravity CLI Gemini migration — <https://antigravity.google/docs/gcli-migration>
 - Cursor CLI parameters — <https://cursor.com/docs/cli/reference/parameters>
+- Claude Code with Pro/Max plan (billing) — <https://support.claude.com/en/articles/11145838-use-claude-code-with-your-pro-or-max-plan>
+- Claude Agent SDK / headless plan usage (2026-06-15 change) — <https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan>

--- a/docs/cloud-automation.md
+++ b/docs/cloud-automation.md
@@ -22,6 +22,16 @@ Do not set `ANTHROPIC_API_KEY` in the routine environment — Routines bill
 against the subscription usage pool, and a present API key suppresses the
 `/schedule` path.
 
+**Why not a local `claude -p` cron?** A laptop that is on daily makes a local
+`launchd`/`cron` job calling `claude -p` look tempting, but it loses on both
+cost and reliability. Headless `claude -p` bills as **per-token API usage** even
+on an OAuth Pro/Max login with no `ANTHROPIC_API_KEY`, and **from 2026-06-15
+Agent SDK / `claude -p` usage no longer counts toward the Claude plan** — the
+subscription pool is reserved for interactive use. A local job also fires only
+when the machine is awake at the scheduled time. A cloud Routine bills against
+the subscription pool and runs regardless of laptop state, so it wins on both.
+(Sources: the two `kind: "billing"` entries in `docs/official-sources.json`.)
+
 ## Recommended Daily Flow
 
 ```text

--- a/docs/official-sources.json
+++ b/docs/official-sources.json
@@ -15,7 +15,8 @@
       "hermes-agent.nousresearch.com",
       "docs.cursor.com",
       "cursor.com",
-      "docs.github.com"
+      "docs.github.com",
+      "support.claude.com"
     ]
   },
   "sources": [
@@ -274,6 +275,22 @@
       "url": "https://antigravity.google/docs/gcli-migration",
       "notes": "JS-rendered SPA; render dynamically to verify. GEMINI_API_KEY->AV_API_KEY env swap is NOT stated here (third-party claim); auth is via OS keyring.",
       "claims": ["agy plugin import gemini", "first-launch auto-conversion", "reads GEMINI.md and AGENTS.md", "global ~/.gemini/GEMINI.md", "workspace skills .gemini/skills -> .agents/skills", "MCP moves to mcp_config.json", "serverUrl schema key", "install ~/.local/bin/agy"]
+    },
+    {
+      "id": "anthropic-claude-code-subscription-billing",
+      "agent": "claude-code",
+      "kind": "billing",
+      "url": "https://support.claude.com/en/articles/11145838-use-claude-code-with-your-pro-or-max-plan",
+      "notes": "Subscription covers interactive Claude Code; a present ANTHROPIC_API_KEY switches Claude Code to pay-as-you-go API billing. Run /status to see which auth method is active.",
+      "claims": ["Pro plan", "Max plan", "subscription covers interactive Claude Code", "ANTHROPIC_API_KEY present switches to API billing", "/status shows auth method", "interactive use covered by plan"]
+    },
+    {
+      "id": "anthropic-agent-sdk-plan-usage",
+      "agent": "claude-code",
+      "kind": "billing",
+      "url": "https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan",
+      "notes": "From 2026-06-15, Agent SDK and claude -p (headless/print) usage no longer counts toward Claude plan limits; the subscription pool is reserved for interactive Claude Code/Cowork. Headless/SDK runs bill as API usage.",
+      "claims": ["Agent SDK with Claude plan", "claude -p headless", "2026-06-15 SDK and claude -p usage no longer counts toward plan limits", "subscription reserved for interactive use", "headless bills as API usage"]
     }
   ]
 }

--- a/prompts/daily-official-doc-update.md
+++ b/prompts/daily-official-doc-update.md
@@ -61,11 +61,26 @@ dynamically before claiming a change. Note when the **2026-06-18 Gemini CLI
 individual cutoff** has passed so the legacy Gemini references can be retired, and
 record any capability the official docs do not cover as `not documented`.
 
+**BILLING / PLAN USAGE — do not skip this category.** Every source in
+`docs/official-sources.json` with `"kind": "billing"` MUST be fetched and
+re-verified every run: which usage the Pro/Max subscription covers vs. what bills
+as API, whether a present `ANTHROPIC_API_KEY` switches Claude Code to API billing,
+and the **2026-06-15** change after which Agent SDK / `claude -p` (headless) usage
+no longer counts toward the Claude plan. If the official docs change any of this,
+update the billing caveat in both mirrors so they stay consistent: the **Billing
+caveat** note in `docs/cli-invocation.md` and the **"Why not a local cron"** block
+in `docs/cloud-automation.md`. Once the 2026-06-15 cutoff has passed, shift the
+wording from future to present tense.
+
 **IF THERE ARE CHANGES:** make small, reviewable edits to the repo docs. Cite the
 official source URL in the docs or in the PR body. Run
 `node scripts/check-official-sources.mjs --write-report`. Do NOT push to main.
 Create a pull request from an `aldegad/`-prefixed branch (the `cc-guard` hook
-rejects branch names containing `claude` or `codex`).
+rejects branch names containing `claude` or `codex`). **Keep history out of the
+doc bodies:** record the change narrative in `CHANGELOG.md` (with the git tag) —
+`SKILL.md` and `docs/*` state current truth only, so replace a changed fact rather
+than appending the old one. A `Last reviewed:` / `verified` stamp is the only
+dated line allowed in a doc body.
 
 **IF THERE ARE NO CHANGES:** do not modify any file. Leave a short no-op summary
 only.


### PR DESCRIPTION
## What

Reframes the package as what it had already grown into — a **cross-runtime agent-platform interoperability wiki** (refreshed daily from official docs) **plus the methodology** to manage it — and adds a billing capability domain.

### Changed
- SKILL.md / README lead with the daily-refreshed **7-runtime** compatibility wiki (Codex, Claude Code, Grok, Hermes, Antigravity CLI, Cursor, Kuma Studio). `Four-Runtime Baseline` → `Runtime Coverage` (all 7). Skill `name` stays `skill-hook-authoring` (install symlinks + `cc-guard` depend on the id).

### Added
- **Billing domain**: `kind: "billing"` sources in `official-sources.json` — Claude Code subscription vs API billing, and the **2026-06-15** change after which Agent SDK / `claude -p` (headless) usage no longer counts toward the Claude plan. Mirrored as a Billing caveat in `cli-invocation.md` and a "Why not a local cron" block in `cloud-automation.md`; daily refresh re-verifies the category.
- **History-out-of-bodies rule** (Core Rules + daily prompt): changelog narrative lives in `CHANGELOG.md` + git tag; doc bodies state current truth only.

### Fixed
- README daily-refresh branch prefix `claude/` → `aldegad/` (`cc-guard` rejects `claude`/`codex` branch names).

## Verification
`node scripts/check-official-sources.mjs --write-report` → PASS (37 sources reachable incl. 2 new `support.claude.com`; SKILL.md 265 lines).