### PR TITLE
feat: auto-merge gate + stale-checkout SessionStart notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ package manifest, so the **git tag plus this file are the version record**
 (the official Claude SKILL.md frontmatter documents only `name` and
 `description`, so the version is intentionally not stamped there).
 
+## v1.3 — 2026-06-09
+
+Closes the daily-refresh loop: the routine can now merge its own docs-only PRs
+behind a deterministic gate, and local checkouts get a nudge when they fall behind.
+
+### Added
+
+- **Auto-merge gate** (`scripts/auto-merge-guard.sh`): squash-merges a refresh PR
+  **only when** the diff is docs/prose-only and `check-official-sources.mjs`
+  passes; otherwise it leaves the PR open for human review. Merge authority sits
+  on the shell gate's exit code, not the agent's judgement. Wired into
+  `prompts/daily-official-doc-update.md` and documented in
+  `docs/cloud-automation.md` (the lightweight "Option A" path — no GitHub Actions
+  or branch protection required).
+- **Stale-checkout notifier** (`scripts/notify-if-stale.sh`): a repo-scoped,
+  read-only, non-blocking Claude Code `SessionStart` hook. Silent when the
+  checkout is current or you are not in this repo; injects a one-line `git pull`
+  heads-up as `additionalContext` when `origin/main` is ahead. Registered in
+  `~/.claude/settings.json` (machine config, not in-repo).
+
+### Changed
+
+- Daily prompt + `README.md`: "you review and merge" → the auto-merge gate handles
+  docs-only passes and everything else waits for review. `Do NOT push to main`
+  softened to "no direct push; merge only via the gate after a PR".
+
 ## v1.2 — 2026-06-09
 
 Repositioning release: the package is now framed as what it had already grown

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The recommended path is **Claude Routines** — a scheduled Claude Code session 
 
 1. In Claude Code, run `/schedule` (or open <https://claude.ai/code/routines>).
 2. Point the routine at this repository and use the prompt in `prompts/daily-official-doc-update.md`.
-3. Schedule it once a day. It opens a PR for you to review and merge (branch-prefix policy is in `docs/cloud-automation.md`).
+3. Schedule it once a day. It opens a PR, then runs an auto-merge gate that squash-merges docs-only changes passing the source check; anything else waits for your review (see `docs/cloud-automation.md`).
 
 Codex users can run the same flow with a Codex App Automation instead. See `docs/cloud-automation.md` for both paths.
 

--- a/docs/cloud-automation.md
+++ b/docs/cloud-automation.md
@@ -76,11 +76,36 @@ behavior of a cloud routine.
 
 Use the same prompt from `prompts/daily-official-doc-update.md`.
 
-## Editing And Review
+## Auto-Merge Gate
 
-- Review the daily PR diff in the repository's Pull Requests tab before merging.
-- Run `node scripts/check-official-sources.mjs --write-report` locally before
-  pushing any manual edits.
-- Optionally enable GitHub auto-merge once branch protection and required checks
-  are in place (the `github` sources in `docs/official-sources.json` cover the
-  official auto-merge and notification docs).
+After the daily routine opens a PR it runs `scripts/auto-merge-guard.sh
+<PR_NUMBER>`, which squash-merges **only when** the diff is docs/prose-only and
+`check-official-sources.mjs` passes — otherwise it leaves the PR open. Merge
+authority sits on that deterministic shell gate, not on the agent's judgement: a
+change that touches code, installers, hooks, or config (or that fails the check)
+always waits for a human. This is the lightweight path — the agent triggers the
+gate, the gate's exit code decides — and it needs no GitHub Actions or
+branch-protection setup.
+
+For manual edits, run `node scripts/check-official-sources.mjs --write-report`
+locally before pushing. Native GitHub auto-merge (`gh pr merge --auto` gated on
+branch protection + required checks) remains a valid alternative — the `github`
+sources in `docs/official-sources.json` cover it — but it is not required for the
+gate above.
+
+## Keeping Local Checkouts In Sync
+
+The wiki's source of truth is the canonical repo, and runtime installs are
+symlinks into it, so a single `git pull` refreshes every runtime at once. To
+avoid forgetting that pull, register `scripts/notify-if-stale.sh` as a Claude
+Code `SessionStart` hook in `~/.claude/settings.json`:
+
+```json
+{ "hooks": { "SessionStart": [ { "hooks": [
+  { "type": "command", "command": "<repo>/scripts/notify-if-stale.sh" } ] } ] } }
+```
+
+It is repo-scoped, read-only, and non-blocking: when the checkout is current (or
+you are not in this repo) it stays silent; when `origin/main` is ahead it injects
+a one-line heads-up that a `git pull` is due. SessionStart hooks cannot block the
+session, so it never interrupts work.

--- a/prompts/daily-official-doc-update.md
+++ b/prompts/daily-official-doc-update.md
@@ -74,18 +74,28 @@ wording from future to present tense.
 
 **IF THERE ARE CHANGES:** make small, reviewable edits to the repo docs. Cite the
 official source URL in the docs or in the PR body. Run
-`node scripts/check-official-sources.mjs --write-report`. Do NOT push to main.
-Create a pull request from an `aldegad/`-prefixed branch (the `cc-guard` hook
-rejects branch names containing `claude` or `codex`). **Keep history out of the
-doc bodies:** record the change narrative in `CHANGELOG.md` (with the git tag) —
-`SKILL.md` and `docs/*` state current truth only, so replace a changed fact rather
-than appending the old one. A `Last reviewed:` / `verified` stamp is the only
-dated line allowed in a doc body.
+`node scripts/check-official-sources.mjs --write-report`. Do NOT push to `main`
+directly. Create a pull request from an `aldegad/`-prefixed branch (the `cc-guard`
+hook rejects branch names containing `claude` or `codex`). **Keep history out of
+the doc bodies:** record the change narrative in `CHANGELOG.md` (with the git tag)
+— `SKILL.md` and `docs/*` state current truth only, so replace a changed fact
+rather than appending the old one. A `Last reviewed:` / `verified` stamp is the
+only dated line allowed in a doc body.
+
+**AUTO-MERGE GATE.** After opening the PR, run
+`scripts/auto-merge-guard.sh <PR_NUMBER>`. The guard squash-merges the PR **only
+if** the diff is docs/prose-only and `check-official-sources.mjs` passes;
+otherwise it exits non-zero and leaves the PR open. Merge **only** on the guard's
+exit 0 — never by your own judgement. If the guard declines (it touched code,
+installers, hooks, or config, or a check failed), stop and leave the PR for a
+human to review. This keeps merge authority on a deterministic gate, not on the
+agent's reasoning.
 
 **IF THERE ARE NO CHANGES:** do not modify any file. Leave a short no-op summary
 only.
 
 **HARD CONSTRAINTS:** Do NOT modify `~/.codex`, `~/.claude`, or any local skill
-install path. Do NOT modify local machine config. Do NOT push to main. Do NOT use
-OpenAI API keys or GitHub Actions secrets. If you need to widen scope beyond
+install path. Do NOT modify local machine config. Do NOT push to `main` directly — merge only
+via `scripts/auto-merge-guard.sh` after a PR. Do NOT use OpenAI API keys or
+GitHub Actions secrets. If you need to widen scope beyond
 this, stop and ask instead of guessing.

--- a/scripts/auto-merge-guard.sh
+++ b/scripts/auto-merge-guard.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# auto-merge-guard.sh — deterministic merge gate for the daily wiki refresh.
+#
+# Usage: scripts/auto-merge-guard.sh <PR_NUMBER> [BASE_REF]
+#
+# The merge decision is NOT a judgement call. This guard squash-merges the PR
+# ONLY when BOTH hold:
+#   1. the diff touches docs/prose only (no code, installer, hook, or config), and
+#   2. `node scripts/check-official-sources.mjs` passes.
+# Otherwise it exits non-zero and leaves the PR open for a human to review.
+# A daily-refresh agent calls this after opening the PR and merges on exit 0;
+# it must never merge by its own reasoning.
+set -euo pipefail
+
+PR="${1:?usage: auto-merge-guard.sh <PR_NUMBER> [BASE_REF]}"
+BASE="${2:-origin/main}"
+
+# Files the guard is willing to auto-merge. Anything else → human review.
+SAFE='^(docs/|prompts/|reports/|SKILL\.md|README\.md|CHANGELOG\.md)$'
+
+changed=$(git diff --name-only "$BASE"...HEAD)
+if [ -z "$changed" ]; then
+  echo "guard: PR #$PR has no diff against $BASE — nothing to merge" >&2
+  exit 1
+fi
+
+unsafe=$(printf '%s\n' "$changed" | grep -vE "$SAFE" || true)
+if [ -n "$unsafe" ]; then
+  echo "guard: PR #$PR changes non-docs files — leaving open for human review:" >&2
+  printf '  %s\n' $unsafe >&2
+  exit 1
+fi
+
+if ! node scripts/check-official-sources.mjs --write-report; then
+  echo "guard: official-source check FAILED — leaving PR #$PR open" >&2
+  exit 1
+fi
+
+gh pr merge "$PR" --squash --delete-branch
+echo "guard: PR #$PR merged (docs-only diff + source check passed)"

--- a/scripts/notify-if-stale.sh
+++ b/scripts/notify-if-stale.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# notify-if-stale.sh — SessionStart hook. Repo-scoped, non-blocking, read-only.
+#
+# Reads the SessionStart JSON payload on stdin. If the session's cwd is a
+# skill-hook-authoring checkout and origin/main is ahead of HEAD, it prints a
+# one-line heads-up as additionalContext so you know the daily wiki refresh
+# landed updates worth a `git pull`. If the checkout is current (or this is not
+# the repo), it exits silently with no output. It never pulls, never writes, and
+# SessionStart hooks cannot block the session regardless.
+#
+# Register in ~/.claude/settings.json:
+#   { "hooks": { "SessionStart": [ { "hooks": [
+#       { "type": "command", "command": "<repo>/scripts/notify-if-stale.sh" } ] } ] } }
+set -uo pipefail
+
+input=$(cat)
+
+# Extract cwd: prefer jq, fall back to a minimal sed parse.
+if command -v jq >/dev/null 2>&1; then
+  cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null)
+else
+  cwd=$(printf '%s' "$input" | sed -n 's/.*"cwd"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+fi
+[ -n "$cwd" ] && cd "$cwd" 2>/dev/null || exit 0
+
+# Scope strictly to this repo; silent everywhere else.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+git remote get-url origin 2>/dev/null | grep -q 'skill-hook-authoring' || exit 0
+
+# Network-bounded fetch; on any failure stay silent rather than nag.
+timeout 5 git fetch --quiet origin main 2>/dev/null || exit 0
+behind=$(git rev-list --count HEAD..origin/main 2>/dev/null) || exit 0
+[ "${behind:-0}" -gt 0 ] || exit 0   # current → silent
+
+last=$(git log -1 --format='%cr' origin/main 2>/dev/null)
+msg="📡 skill-hook-authoring: origin/main is ${behind} commit(s) ahead (latest ${last}). The daily wiki refresh landed updates — \`git pull\` to sync this checkout."
+printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":%s}}\n' \
+  "$(printf '%s' "$msg" | { jq -Rs . 2>/dev/null || printf '"%s"' "$msg"; })"
+exit 0


### PR DESCRIPTION
## What
Closes the daily-refresh loop (the **Option A** path) and removes the "forgot to `git pull`" friction.

### Added
- **`scripts/auto-merge-guard.sh`** — deterministic merge gate. Squash-merges a refresh PR **only when** the diff is docs/prose-only **and** `check-official-sources.mjs` passes; otherwise exits non-zero and leaves the PR open. Merge authority is on the shell gate's exit code, **not** the agent's judgement. The daily prompt now calls it after opening the PR.
- **`scripts/notify-if-stale.sh`** — repo-scoped, read-only, **non-blocking** Claude Code `SessionStart` hook. Silent when the checkout is current (or you're not in this repo); injects a one-line `git pull` heads-up as `additionalContext` when `origin/main` is ahead. Registered in `~/.claude/settings.json` (machine config, not in-repo).

### Changed
- Daily prompt / README / cloud-automation.md updated for the gate; `Do NOT push to main` → "no direct push; merge only via the gate after a PR". CHANGELOG v1.3.

## Verification
- `check-official-sources.mjs` → PASS (37 sources, SKILL.md 265 lines)
- both scripts `bash -n` clean, committed `100755`
- notify-if-stale: silent when current + silent outside repo (tested); stale-case output validated as JSON