### PR TITLE
feat: install-local.mjs (Claude/Codex) + Codex stale-notifier support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ package manifest, so the **git tag plus this file are the version record**
 (the official Claude SKILL.md frontmatter documents only `name` and
 `description`, so the version is intentionally not stamped there).
 
+## v1.4 — 2026-06-09
+
+Local install automation for the two runtimes with stable install/hook surfaces
+(Claude + Codex), and the stale notifier extended to cover Codex.
+
+### Added
+
+- **`scripts/install-local.mjs`** — local installer. `--runtime claude|codex|both`,
+  `--link symlink|copy`, `--with-stale-hook`, `--dry-run`. Symlinks (or copies)
+  the skill into `~/.<runtime>/skills/`, is idempotent, backs up any JSON it
+  patches, and skips a runtime whose `~/.<runtime>` root is absent.
+
+### Changed
+
+- **Stale-checkout notifier now covers Codex.** `scripts/notify-if-stale.sh`
+  auto-detects the hook event: Claude `SessionStart` (once per session) and Codex
+  `PreToolUse` (per tool call, self-throttled ~6h via a stamp file). It injects
+  `additionalContext` with no `permissionDecision`, so the tool call proceeds
+  normally and nothing blocks. `install-local.mjs --with-stale-hook` registers it
+  on the matrix-correct event per runtime. The `docs/cloud-automation.md` install
+  section was rewritten around the installer; the notifier stays opt-in.
+
 ## v1.3 — 2026-06-09
 
 Closes the daily-refresh loop: the routine can now merge its own docs-only PRs

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Every compatibility claim cites the vendor's own docs; where a runtime does not 
 - `docs/official-sources.json` is the source manifest that the daily refresh re-verifies.
 - `docs/cloud-automation.md` explains the daily update automation and why it runs in the cloud, not locally.
 - `docs/kuma-studio-patterns.md` captures public Kuma Studio operating patterns.
+- `scripts/install-local.mjs` installs the skill into Claude/Codex and can wire the opt-in stale-checkout notifier (`scripts/notify-if-stale.sh`).
 - `CHANGELOG.md` plus the git tag are the version record. History stays here, not in the doc bodies.
 
 ## Daily Wiki Refresh

--- a/docs/cloud-automation.md
+++ b/docs/cloud-automation.md
@@ -93,19 +93,28 @@ branch protection + required checks) remains a valid alternative — the `github
 sources in `docs/official-sources.json` cover it — but it is not required for the
 gate above.
 
-## Keeping Local Checkouts In Sync
+## Installing Locally + Keeping Checkouts In Sync
 
-The wiki's source of truth is the canonical repo, and runtime installs are
-symlinks into it, so a single `git pull` refreshes every runtime at once. To
-avoid forgetting that pull, register `scripts/notify-if-stale.sh` as a Claude
-Code `SessionStart` hook in `~/.claude/settings.json`:
+The canonical repo is the source of truth; runtime installs are symlinks into it,
+so a single `git pull` refreshes every runtime at once. Install — and optionally
+wire the stale notifier — with `scripts/install-local.mjs`:
 
-```json
-{ "hooks": { "SessionStart": [ { "hooks": [
-  { "type": "command", "command": "<repo>/scripts/notify-if-stale.sh" } ] } ] } }
+```bash
+node scripts/install-local.mjs --runtime both --with-stale-hook   # claude + codex
+node scripts/install-local.mjs --dry-run --with-stale-hook        # preview, changes nothing
 ```
 
-It is repo-scoped, read-only, and non-blocking: when the checkout is current (or
-you are not in this repo) it stays silent; when `origin/main` is ahead it injects
-a one-line heads-up that a `git pull` is due. SessionStart hooks cannot block the
-session, so it never interrupts work.
+The installer symlinks the skill into `~/.claude/skills/` and/or `~/.codex/skills/`
+(`--link copy` copies instead), and with `--with-stale-hook` registers
+`scripts/notify-if-stale.sh` on the **matrix-correct event per runtime**:
+`SessionStart` for Claude, a throttled `PreToolUse` (matcher `*`) for Codex, which
+has no SessionStart. It is idempotent and backs up any JSON it patches; it skips a
+runtime whose `~/.<runtime>` root is absent.
+
+The notifier is **opt-in and a convenience only** — not required for the wiki or
+the auto-merge gate. It is repo-scoped, read-only, and non-blocking: silent when
+the checkout is current (or you are not in this repo), a one-line `git pull`
+heads-up when `origin/main` is ahead; neither event can block a session. Local
+install automation covers **Claude and Codex** only — the other tracked runtimes
+have no documented session-start hook, so use a shell-profile cwd guard or a
+manual `git pull` there.

--- a/scripts/install-local.mjs
+++ b/scripts/install-local.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// install-local.mjs — install this skill into Claude and/or Codex, with an
+// opt-in stale-checkout notifier hook.
+//
+// The wiki tracks seven runtimes, but local install automation covers the two
+// with documented, stable install + hook surfaces: Claude Code and Codex. The
+// stale-hook event is matrix-gated per runtime (Claude=SessionStart,
+// Codex=PreToolUse); runtimes without a documented session-start hook are not
+// auto-installed — use a shell-profile cwd guard or a manual `git pull` there.
+//
+// Usage:
+//   node scripts/install-local.mjs [--runtime claude|codex|both]
+//                                  [--link symlink|copy]
+//                                  [--with-stale-hook] [--dry-run]
+// All JSON patches are idempotent and back up the file first.
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SKILL_ID = "skill-hook-authoring";
+const notifyHook = path.join(repoRoot, "scripts", "notify-if-stale.sh");
+
+const opts = { runtime: "both", link: "symlink", staleHook: false, dryRun: false };
+const argv = process.argv.slice(2);
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  if (a === "--runtime") opts.runtime = argv[++i];
+  else if (a === "--link") opts.link = argv[++i];
+  else if (a === "--with-stale-hook") opts.staleHook = true;
+  else if (a === "--dry-run") opts.dryRun = true;
+  else if (a === "--help" || a === "-h") { usage(); process.exit(0); }
+  else { console.error(`unknown arg: ${a}`); usage(); process.exit(1); }
+}
+function usage() {
+  console.log(`Usage: node scripts/install-local.mjs [options]
+  --runtime claude|codex|both   runtime(s) to install into (default both)
+  --link symlink|copy           install the skill as a symlink or a copy (default symlink)
+  --with-stale-hook             also register the opt-in stale-checkout notifier
+  --dry-run                     print actions without changing anything
+  -h, --help                    this help
+
+Stale-hook event per runtime: claude -> SessionStart, codex -> PreToolUse ("*", self-throttled).`);
+}
+if (!["claude", "codex", "both"].includes(opts.runtime)) { console.error('--runtime must be claude|codex|both'); process.exit(1); }
+if (!["symlink", "copy"].includes(opts.link)) { console.error('--link must be symlink|copy'); process.exit(1); }
+const RUNTIMES = opts.runtime === "both" ? ["claude", "codex"] : [opts.runtime];
+
+const tag = opts.dryRun ? "[dry-run]" : "[install]";
+const log = (...m) => console.log(tag, ...m);
+
+function isSymlink(p) { try { return fs.lstatSync(p).isSymbolicLink(); } catch { return false; } }
+function exists(p) { try { fs.lstatSync(p); return true; } catch { return false; } }
+
+function backup(file) {
+  if (!fs.existsSync(file)) return;
+  const bak = `${file}.bak`;
+  if (opts.dryRun) { log(`would back up ${file} -> ${bak}`); return; }
+  fs.copyFileSync(file, bak);
+  log(`backed up ${file} -> ${bak}`);
+}
+function readJson(file) {
+  if (!fs.existsSync(file)) return {};
+  try { return JSON.parse(fs.readFileSync(file, "utf8")); }
+  catch (e) { console.error(`refusing to patch malformed JSON: ${file} (${e.message})`); process.exit(1); }
+}
+function writeJson(file, obj) {
+  if (opts.dryRun) { log(`would write ${file}`); return; }
+  fs.writeFileSync(file, JSON.stringify(obj, null, 2) + "\n");
+  log(`wrote ${file}`);
+}
+function hasCommand(groups, cmd) {
+  return Array.isArray(groups) && groups.some((g) => Array.isArray(g.hooks) && g.hooks.some((h) => h.command === cmd));
+}
+
+function installSkill(rt) {
+  const rtRoot = path.join(os.homedir(), `.${rt}`);
+  if (!fs.existsSync(rtRoot)) { log(`~/.${rt} not found — skipping ${rt} (runtime not installed)`); return false; }
+  const skillsDir = path.join(rtRoot, "skills");
+  const dest = path.join(skillsDir, SKILL_ID);
+
+  if (exists(dest)) {
+    if (isSymlink(dest)) {
+      const resolved = path.resolve(skillsDir, fs.readlinkSync(dest));
+      if (resolved === repoRoot) { log(`${rt}: skill symlink already correct (${dest})`); return true; }
+      log(`${rt}: ${dest} symlinks to ${resolved}, not this repo — leaving as-is, resolve manually`); return false;
+    }
+    log(`${rt}: ${dest} exists and is not a symlink — leaving as-is, resolve manually`); return false;
+  }
+  if (opts.dryRun) { log(`would ${opts.link === "symlink" ? "symlink" : "copy"} ${dest} <- ${repoRoot}`); return true; }
+  fs.mkdirSync(skillsDir, { recursive: true });
+  if (opts.link === "symlink") { fs.symlinkSync(repoRoot, dest); log(`${rt}: symlinked ${dest} -> ${repoRoot}`); }
+  else { fs.cpSync(repoRoot, dest, { recursive: true }); log(`${rt}: copied repo -> ${dest}`); }
+  return true;
+}
+
+function registerStaleHook(rt) {
+  const rtRoot = path.join(os.homedir(), `.${rt}`);
+  if (!fs.existsSync(rtRoot)) { log(`~/.${rt} not found — cannot register hook for ${rt}`); return; }
+  const event = rt === "claude" ? "SessionStart" : "PreToolUse";
+  const file = path.join(rtRoot, rt === "claude" ? "settings.json" : "hooks.json");
+  const cfg = readJson(file);
+  cfg.hooks = cfg.hooks || {};
+  cfg.hooks[event] = cfg.hooks[event] || [];
+  if (hasCommand(cfg.hooks[event], notifyHook)) { log(`${rt}: ${event} notifier already registered — skip`); return; }
+  backup(file);
+  const entry = rt === "claude"
+    ? { hooks: [{ type: "command", command: notifyHook }] }
+    : { matcher: "*", hooks: [{ type: "command", command: notifyHook, timeout: 30 }] };
+  cfg.hooks[event].push(entry);
+  writeJson(file, cfg);
+  log(`${rt}: registered ${event} stale-checkout notifier`);
+}
+
+console.log(`skill-hook-authoring local installer`);
+console.log(`repo: ${repoRoot}`);
+console.log(`runtime(s): ${RUNTIMES.join(", ")} | link: ${opts.link} | stale-hook: ${opts.staleHook} | dry-run: ${opts.dryRun}\n`);
+for (const rt of RUNTIMES) {
+  const ok = installSkill(rt);
+  if (ok && opts.staleHook) registerStaleHook(rt);
+}
+console.log(`\ndone.${opts.dryRun ? " (dry-run — nothing changed)" : ""}`);
+if (opts.staleHook) console.log(`stale notifier script: ${notifyHook}`);

--- a/scripts/notify-if-stale.sh
+++ b/scripts/notify-if-stale.sh
@@ -1,31 +1,46 @@
 #!/usr/bin/env bash
-# notify-if-stale.sh — SessionStart hook. Repo-scoped, non-blocking, read-only.
+# notify-if-stale.sh — stale-checkout notifier for Claude and Codex.
+# Repo-scoped, read-only, non-blocking, opt-in (registered by install-local.mjs).
 #
-# Reads the SessionStart JSON payload on stdin. If the session's cwd is a
-# skill-hook-authoring checkout and origin/main is ahead of HEAD, it prints a
-# one-line heads-up as additionalContext so you know the daily wiki refresh
-# landed updates worth a `git pull`. If the checkout is current (or this is not
-# the repo), it exits silently with no output. It never pulls, never writes, and
-# SessionStart hooks cannot block the session regardless.
+# Reads the hook JSON payload on stdin and AUTO-DETECTS the event:
+#   - SessionStart (Claude) : fires once per session start/resume.
+#   - PreToolUse  (Codex)   : fires per tool call, so it self-throttles (default 6h).
+# In both cases: if cwd is a skill-hook-authoring checkout and origin/main is
+# ahead of HEAD, it injects a one-line `git pull` heads-up as additionalContext.
+# Otherwise (current / not this repo / throttled / any error) it stays silent.
+# It never pulls, never writes repo state, and neither event can block a session.
 #
-# Register in ~/.claude/settings.json:
-#   { "hooks": { "SessionStart": [ { "hooks": [
-#       { "type": "command", "command": "<repo>/scripts/notify-if-stale.sh" } ] } ] } }
+# Both Claude Code and Codex share the same hookSpecificOutput.additionalContext
+# schema; with no permissionDecision the tool call proceeds normally.
 set -uo pipefail
 
-input=$(cat)
+THROTTLE_SECONDS="${STALE_THROTTLE_SECONDS:-21600}"   # 6h; applies to PreToolUse only
+STAMP="${TMPDIR:-/tmp}/skill-hook-authoring-stale.stamp"
 
-# Extract cwd: prefer jq, fall back to a minimal sed parse.
-if command -v jq >/dev/null 2>&1; then
-  cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null)
-else
-  cwd=$(printf '%s' "$input" | sed -n 's/.*"cwd"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
-fi
+input=$(cat)
+get() {   # get <key> — jq if present, else a minimal sed parse
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$input" | jq -r --arg k "$1" '.[$k] // empty' 2>/dev/null
+  else
+    printf '%s' "$input" | sed -n "s/.*\"$1\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p"
+  fi
+}
+
+event=$(get hook_event_name)
+cwd=$(get cwd)
 [ -n "$cwd" ] && cd "$cwd" 2>/dev/null || exit 0
 
 # Scope strictly to this repo; silent everywhere else.
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 git remote get-url origin 2>/dev/null | grep -q 'skill-hook-authoring' || exit 0
+
+# PreToolUse fires per tool call: throttle so we fetch at most once per window.
+now=$(date +%s 2>/dev/null || echo 0)
+if [ "$event" = "PreToolUse" ] && [ -f "$STAMP" ]; then
+  mtime=$(stat -f %m "$STAMP" 2>/dev/null || stat -c %Y "$STAMP" 2>/dev/null || echo 0)
+  [ $(( now - mtime )) -lt "$THROTTLE_SECONDS" ] && exit 0
+fi
+: > "$STAMP" 2>/dev/null || true   # refresh the throttle window (also silences a failed fetch for the window)
 
 # Network-bounded fetch; on any failure stay silent rather than nag.
 timeout 5 git fetch --quiet origin main 2>/dev/null || exit 0
@@ -34,6 +49,7 @@ behind=$(git rev-list --count HEAD..origin/main 2>/dev/null) || exit 0
 
 last=$(git log -1 --format='%cr' origin/main 2>/dev/null)
 msg="📡 skill-hook-authoring: origin/main is ${behind} commit(s) ahead (latest ${last}). The daily wiki refresh landed updates — \`git pull\` to sync this checkout."
-printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":%s}}\n' \
-  "$(printf '%s' "$msg" | { jq -Rs . 2>/dev/null || printf '"%s"' "$msg"; })"
+ev="${event:-SessionStart}"
+printf '{"hookSpecificOutput":{"hookEventName":"%s","additionalContext":%s}}\n' \
+  "$ev" "$(printf '%s' "$msg" | { jq -Rs . 2>/dev/null || printf '"%s"' "$msg"; })"
 exit 0


### PR DESCRIPTION
## What
Local install automation for the two runtimes with stable install/hook surfaces — **Claude + Codex** — and extends the opt-in stale notifier to cover Codex (which has no `SessionStart`).

### Added
- **`scripts/install-local.mjs`** — `--runtime claude|codex|both`, `--link symlink|copy`, `--with-stale-hook`, `--dry-run`. Symlinks (or copies) the skill into `~/.<runtime>/skills/`; idempotent; backs up any JSON it patches; skips a runtime whose root is absent.

### Changed
- **`scripts/notify-if-stale.sh` auto-detects the event** — Claude `SessionStart` (once per session) and Codex `PreToolUse` (per tool call, self-throttled ~6h via stamp file). Injects `additionalContext` with **no `permissionDecision`** so the tool proceeds normally and nothing blocks (confirmed against the official hooks docs; matcher `*`).
- `install-local.mjs --with-stale-hook` registers it on the matrix-correct event per runtime. `cloud-automation.md` install section rewritten; notifier stays **opt-in**. README + CHANGELOG v1.4.

## Verification
- `node --check` (mjs) + `bash -n` (sh) clean; scripts committed `100755`
- `--dry-run --with-stale-hook --runtime both`: detects existing correct symlinks, previews backup+register, **changes nothing**
- `check-official-sources.mjs` → PASS (37 sources, SKILL.md 265 lines)