### PR TITLE
docs: 2026-06-26 daily refresh — billing re-verified live (still paused), advance freshness stamps 06-25 → 06-26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ package manifest, so the **git tag plus this file are the version record**
 (the official Claude SKILL.md frontmatter documents only `name` and
 `description`, so the version is intentionally not stamped there).
 
+## v1.16 — 2026-06-26
+
+Daily refresh: billing status re-verified live, unchanged; freshness stamps advanced.
+
+### Changed
+
+- **Billing status re-verified live 2026-06-26, still paused.** The official
+  support page banner still reads *"Update June 15: We're pausing the changes to
+  Claude Agent SDK usage described below. For now, nothing has changed: Claude
+  Agent SDK, `claude -p`, and third-party app usage still draw from your
+  subscription's usage limits."* The Pro/Max page (subscription covers interactive
+  Claude Code; a present `ANTHROPIC_API_KEY` switches to pay-as-you-go API billing;
+  `/status` monitors allocation) is also unchanged. Advanced every billing
+  time-sensitive stamp 06-25 → 06-26 (`cli-invocation.md`, `cloud-automation.md`,
+  `official-sources.json`, the daily prompt) per the freshness-stamp carve-out. No
+  structural facts changed; the Gemini cutoff (2026-06-18, a settled past event)
+  and the Antigravity SPA render stamps (06-22, structural — re-rendered live this
+  run via Playwright + system Chrome, slash commands/conversation scoping
+  unchanged) were left untouched.
+
 ## v1.15 — 2026-06-25
 
 Daily refresh: billing status re-verified live, unchanged; freshness stamps advanced.

--- a/docs/cli-invocation.md
+++ b/docs/cli-invocation.md
@@ -1,6 +1,6 @@
 # CLI Spawn And Session Resume
 
-Last reviewed: 2026-06-25
+Last reviewed: 2026-06-26
 
 How to spawn each runtime **interactively** (a human-facing TUI session) versus
 **non-interactively** (headless / print / one-shot, for a script, hook, or
@@ -68,7 +68,7 @@ the same idea, but they are reached differently:
 
 > **Billing caveat (Claude Code).** On a subscription, `claude -p` and Agent SDK
 > runs draw from your plan's usage limits — the same pool as interactive use, with
-> no separate per-run credit. As of 2026-06-25, the Agent SDK billing
+> no separate per-run credit. As of 2026-06-26, the Agent SDK billing
 > change announced for 2026-06-15 remains **paused**. The official support page
 > opens with a dated banner: *"Update June 15: We're pausing the changes to Claude
 > Agent SDK usage described below. For now, nothing has changed: Claude Agent SDK,
@@ -79,7 +79,7 @@ the same idea, but they are reached differently:
 > `claude -p` cron; the reliability advantage (Routine runs regardless of laptop
 > state) still applies. See `docs/cloud-automation.md`. (Source:
 > https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan,
-> verified 2026-06-25.)
+> verified 2026-06-26.)
 
 ## C. Resume invocation (command syntax)
 
@@ -158,7 +158,7 @@ Official (Google Developers Blog, posted 2026-05-19; antigravity.google docs):
   (JSONL); Claude/Cursor `--output-format json|stream-json`; Grok
   `--output-format json`. Hermes and Antigravity document **no** headless JSON
   output flag.
-- **Claude Code Agent SDK billing (status as of 2026-06-25):** The billing change planned for 2026-06-15 remains **paused** — `claude -p` and Agent SDK usage on subscription plans continues drawing from the same usage limits as interactive sessions. The separate monthly credit scheme is not active. For `ANTHROPIC_API_KEY` users billing remains pay-as-you-go. For scripted/CI runs against a subscription, authenticate with `claude setup-token` (a long-lived OAuth token, requires a subscription) rather than an API key, and pass `--output-format json` to capture `total_cost_usd` plus a per-model cost breakdown per invocation. Note that `--bare` skips OAuth/keychain, so it needs `ANTHROPIC_API_KEY` or an `apiKeyHelper` (via `--settings`) — i.e. bare mode implies API-key billing unless an `apiKeyHelper` is supplied. (Source: https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan, verified 2026-06-25.)
+- **Claude Code Agent SDK billing (status as of 2026-06-26):** The billing change planned for 2026-06-15 remains **paused** — `claude -p` and Agent SDK usage on subscription plans continues drawing from the same usage limits as interactive sessions. The separate monthly credit scheme is not active. For `ANTHROPIC_API_KEY` users billing remains pay-as-you-go. For scripted/CI runs against a subscription, authenticate with `claude setup-token` (a long-lived OAuth token, requires a subscription) rather than an API key, and pass `--output-format json` to capture `total_cost_usd` plus a per-model cost breakdown per invocation. Note that `--bare` skips OAuth/keychain, so it needs `ANTHROPIC_API_KEY` or an `apiKeyHelper` (via `--settings`) — i.e. bare mode implies API-key billing unless an `apiKeyHelper` is supplied. (Source: https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan, verified 2026-06-26.)
 - Session resume identifiers differ (UUID session id vs. human name vs.
   `--last` / `-1` vs. `--conversation <uuid>`). Store a resume handle in the form
   that runtime's resume command accepts, and remember whether you need the
@@ -184,4 +184,4 @@ Official (Google Developers Blog, posted 2026-05-19; antigravity.google docs):
 - Antigravity SDK (programmatic/headless path) — <https://antigravity.google/docs/sdk-overview>
 - Cursor CLI parameters — <https://cursor.com/docs/cli/reference/parameters>
 - Claude Code with Pro/Max plan (billing) — <https://support.claude.com/en/articles/11145838-use-claude-code-with-your-pro-or-max-plan>
-- Claude Agent SDK / headless plan usage (2026-06-15 change **paused**, still paused as of 2026-06-25) — <https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan>
+- Claude Agent SDK / headless plan usage (2026-06-15 change **paused**, still paused as of 2026-06-26) — <https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan>

--- a/docs/cloud-automation.md
+++ b/docs/cloud-automation.md
@@ -1,6 +1,6 @@
 # Cloud Automation
 
-Last reviewed: 2026-06-25
+Last reviewed: 2026-06-26
 
 Keep this repo's compatibility docs current by running a daily agent that reads
 `docs/official-sources.json`, fetches the official vendor URLs, and opens a pull
@@ -26,7 +26,7 @@ against the subscription usage pool, and a present API key suppresses the
 `launchd`/`cron` job calling `claude -p` look tempting, but the primary
 drawback is **reliability**: a local job fires only when the machine is awake
 at the scheduled time, while a cloud Routine runs regardless of laptop state.
-Note: as of 2026-06-25 the billing difference described here previously (a
+Note: as of 2026-06-26 the billing difference described here previously (a
 separate monthly Agent SDK credit) remains **paused** — `claude -p` and
 Agent SDK usage on subscription plans draw from the same usage pool as
 interactive sessions (no separate per-run credit). For `ANTHROPIC_API_KEY` users billing remains

--- a/docs/official-sources.json
+++ b/docs/official-sources.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updated": "2026-06-25",
+  "updated": "2026-06-26",
   "policy": {
     "sourceRule": "Use only official vendor documentation for compatibility claims. If the official docs do not document a capability, record not documented or unknown.",
     "mainBranchRule": "Daily automation must create a PR; it must not push directly to main.",
@@ -1129,11 +1129,11 @@
       "agent": "claude-code",
       "kind": "billing",
       "url": "https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan",
-      "notes": "Re-verified 2026-06-25: the billing change originally planned for 2026-06-15 is still PAUSED. The page opens with a dated banner: 'Update June 15: We're pausing the changes to Claude Agent SDK usage described below. For now, nothing has changed: Claude Agent SDK, claude -p, and third-party app usage still draw from your subscription's usage limits.' Accounts using an API key continue on pay-as-you-go API billing. The original plan described separate monthly credits per plan tier (Pro $20, Max 5x $100, Max 20x $200, Team Standard $20, Team Premium $100, Enterprise $200) but this plan is paused and not in effect.",
+      "notes": "Re-verified 2026-06-26: the billing change originally planned for 2026-06-15 is still PAUSED. The page opens with a dated banner: 'Update June 15: We're pausing the changes to Claude Agent SDK usage described below. For now, nothing has changed: Claude Agent SDK, claude -p, and third-party app usage still draw from your subscription's usage limits.' Accounts using an API key continue on pay-as-you-go API billing. The original plan described separate monthly credits per plan tier (Pro $20, Max 5x $100, Max 20x $200, Team Standard $20, Team Premium $100, Enterprise $200) but this plan is paused and not in effect.",
       "claims": [
         "Agent SDK with Claude plan",
         "claude -p headless",
-        "2026-06-15 Agent SDK billing change still paused as of 2026-06-25",
+        "2026-06-15 Agent SDK billing change still paused as of 2026-06-26",
         "Agent SDK and claude -p currently draw from regular subscription usage limits same as interactive use",
         "API key accounts remain pay-as-you-go API billing",
         "original plan described separate monthly credits per plan tier but change is paused"

--- a/prompts/daily-official-doc-update.md
+++ b/prompts/daily-official-doc-update.md
@@ -67,7 +67,7 @@ do not cover as `not documented`.
 re-verified every run: which usage the Pro/Max subscription covers vs. what bills
 as API, whether a present `ANTHROPIC_API_KEY` switches Claude Code to API billing,
 and the status of the **2026-06-15** Agent SDK / `claude -p` plan-usage change.
-As of 2026-06-25 that change is **paused** (Agent SDK and `claude -p` still draw
+As of 2026-06-26 that change is **paused** (Agent SDK and `claude -p` still draw
 from the subscription usage limits, same as interactive use — no separate per-run
 credit). Confirm each run whether it is still paused, resumed, or cancelled, and
 keep the status + date current. This is a **time-sensitive status claim**: advance


### PR DESCRIPTION
Re-verified the Claude Agent SDK / claude -p billing status against the official
support page: the 'Update June 15' pause banner is still present and the change
remains paused (Agent SDK + claude -p still draw from subscription usage limits).
Pro/Max page unchanged. Antigravity SPA re-rendered live (Playwright + system
Chrome) — slash commands, conversation scoping, plugin layout unchanged.

Advanced the time-sensitive billing stamps 06-25 → 06-26 in cli-invocation.md,
cloud-automation.md, official-sources.json, and the daily prompt. No structural
facts changed; structural stamps (06-22 Antigravity render, Gemini 06-18 cutoff)
left untouched per the low-noise freshness rule.
