### PR TITLE
docs: 2026-06-29 daily refresh — billing re-verified live (still paused); advance freshness stamps 06-28 → 06-29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ package manifest, so the **git tag plus this file are the version record**
 (the official Claude SKILL.md frontmatter documents only `name` and
 `description`, so the version is intentionally not stamped there).
 
+## v1.20 — 2026-06-29
+
+Daily refresh: billing re-verified live, still paused; freshness stamps advanced.
+
+### Changed
+
+- **Billing status re-verified live 2026-06-29, still paused.** The official
+  support page banner still reads *"Update June 15: We're pausing the changes to
+  Claude Agent SDK usage described below. For now, nothing has changed: Claude
+  Agent SDK, `claude -p`, and third-party app usage still draw from your
+  subscription's usage limits."* The Pro/Max page still confirms the subscription
+  covers interactive Claude Code, a present `ANTHROPIC_API_KEY` switches to
+  pay-as-you-go API billing, and `/status` monitors plan allocation. Advanced
+  every billing time-sensitive stamp 06-28 → 06-29 (`cli-invocation.md`,
+  `cloud-automation.md`, `official-sources.json`, the daily prompt) per the
+  freshness-stamp carve-out. No structural facts changed. (Source:
+  https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
+
+### Notes
+
+- **No structural drift this run.** Codex, Claude, Grok, Hermes, Cursor, and
+  GitHub sources re-verified with no material drift; the two facts recorded
+  yesterday (plugins-reference experimental `themes/` + `channels` field; headless
+  10-minute background-subagent wait cap since v2.1.182) were re-confirmed still
+  present and accurate. The gajae-code README re-verified, no drift; its
+  structural `verified 2026-06-27` stamp was left as-is per the low-noise freshness
+  rule.
+- **Antigravity SPA unverified this run.** The `antigravity.google` docs are a
+  JS-rendered SPA and `claude-in-chrome` was not connected this run, so the six
+  Antigravity sources could not be dynamically rendered; recorded as *unverified
+  this run* and their structural render stamps (06-22) left untouched (no change
+  claimed).
+
 ## v1.19 — 2026-06-28
 
 Daily refresh: billing re-verified live (still paused); two verified Claude doc

--- a/docs/cli-invocation.md
+++ b/docs/cli-invocation.md
@@ -1,6 +1,6 @@
 # CLI Spawn And Session Resume
 
-Last reviewed: 2026-06-28
+Last reviewed: 2026-06-29
 
 How to spawn each runtime **interactively** (a human-facing TUI session) versus
 **non-interactively** (headless / print / one-shot, for a script, hook, or
@@ -73,7 +73,7 @@ the same idea, but they are reached differently:
 
 > **Billing caveat (Claude Code).** On a subscription, `claude -p` and Agent SDK
 > runs draw from your plan's usage limits — the same pool as interactive use, with
-> no separate per-run credit. As of 2026-06-28, the Agent SDK billing
+> no separate per-run credit. As of 2026-06-29, the Agent SDK billing
 > change announced for 2026-06-15 remains **paused**. The official support page
 > opens with a dated banner: *"Update June 15: We're pausing the changes to Claude
 > Agent SDK usage described below. For now, nothing has changed: Claude Agent SDK,
@@ -84,7 +84,7 @@ the same idea, but they are reached differently:
 > `claude -p` cron; the reliability advantage (Routine runs regardless of laptop
 > state) still applies. See `docs/cloud-automation.md`. (Source:
 > https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan,
-> verified 2026-06-28.)
+> verified 2026-06-29.)
 
 ## C. Resume invocation (command syntax)
 
@@ -164,7 +164,7 @@ Official (Google Developers Blog, posted 2026-05-19; antigravity.google docs):
   (JSONL); Claude/Cursor `--output-format json|stream-json`; Grok
   `--output-format json`. Hermes and Antigravity document **no** headless JSON
   output flag.
-- **Claude Code Agent SDK billing (status as of 2026-06-28):** The billing change planned for 2026-06-15 remains **paused** — `claude -p` and Agent SDK usage on subscription plans continues drawing from the same usage limits as interactive sessions. The separate monthly credit scheme is not active. For `ANTHROPIC_API_KEY` users billing remains pay-as-you-go. For scripted/CI runs against a subscription, authenticate with `claude setup-token` (a long-lived OAuth token, requires a subscription) rather than an API key, and pass `--output-format json` to capture `total_cost_usd` plus a per-model cost breakdown per invocation. Note that `--bare` skips OAuth/keychain, so it needs `ANTHROPIC_API_KEY` or an `apiKeyHelper` (via `--settings`) — i.e. bare mode implies API-key billing unless an `apiKeyHelper` is supplied. (Source: https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan, verified 2026-06-28.)
+- **Claude Code Agent SDK billing (status as of 2026-06-29):** The billing change planned for 2026-06-15 remains **paused** — `claude -p` and Agent SDK usage on subscription plans continues drawing from the same usage limits as interactive sessions. The separate monthly credit scheme is not active. For `ANTHROPIC_API_KEY` users billing remains pay-as-you-go. For scripted/CI runs against a subscription, authenticate with `claude setup-token` (a long-lived OAuth token, requires a subscription) rather than an API key, and pass `--output-format json` to capture `total_cost_usd` plus a per-model cost breakdown per invocation. Note that `--bare` skips OAuth/keychain, so it needs `ANTHROPIC_API_KEY` or an `apiKeyHelper` (via `--settings`) — i.e. bare mode implies API-key billing unless an `apiKeyHelper` is supplied. (Source: https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan, verified 2026-06-29.)
 - Session resume identifiers differ (UUID session id vs. human name vs.
   `--last` / `-1` vs. `--conversation <uuid>`). Store a resume handle in the form
   that runtime's resume command accepts, and remember whether you need the
@@ -191,4 +191,4 @@ Official (Google Developers Blog, posted 2026-05-19; antigravity.google docs):
 - Cursor CLI parameters — <https://cursor.com/docs/cli/reference/parameters>
 - gajae-code (community project, README — not vendor docs) — <https://github.com/Yeachan-Heo/gajae-code>
 - Claude Code with Pro/Max plan (billing) — <https://support.claude.com/en/articles/11145838-use-claude-code-with-your-pro-or-max-plan>
-- Claude Agent SDK / headless plan usage (2026-06-15 change **paused**, still paused as of 2026-06-28) — <https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan>
+- Claude Agent SDK / headless plan usage (2026-06-15 change **paused**, still paused as of 2026-06-29) — <https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan>

--- a/docs/cloud-automation.md
+++ b/docs/cloud-automation.md
@@ -1,6 +1,6 @@
 # Cloud Automation
 
-Last reviewed: 2026-06-28
+Last reviewed: 2026-06-29
 
 Keep this repo's compatibility docs current by running a daily agent that reads
 `docs/official-sources.json`, fetches the official vendor URLs, and opens a pull
@@ -26,7 +26,7 @@ against the subscription usage pool, and a present API key suppresses the
 `launchd`/`cron` job calling `claude -p` look tempting, but the primary
 drawback is **reliability**: a local job fires only when the machine is awake
 at the scheduled time, while a cloud Routine runs regardless of laptop state.
-Note: as of 2026-06-28 the billing difference described here previously (a
+Note: as of 2026-06-29 the billing difference described here previously (a
 separate monthly Agent SDK credit) remains **paused** — `claude -p` and
 Agent SDK usage on subscription plans draw from the same usage pool as
 interactive sessions (no separate per-run credit). For `ANTHROPIC_API_KEY` users billing remains

--- a/docs/official-sources.json
+++ b/docs/official-sources.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updated": "2026-06-28",
+  "updated": "2026-06-29",
   "policy": {
     "sourceRule": "Use only official vendor documentation for compatibility claims. If the official docs do not document a capability, record not documented or unknown.",
     "nonVendorRule": "A small number of non-vendor runtimes (e.g. gajae-code, a community/MIT project) are tracked from their own project README rather than vendor docs. They must be explicitly flagged as community/non-vendor in the docs, held to the same not-documented discipline, and never presented as official vendor guarantees.",
@@ -1137,11 +1137,11 @@
       "agent": "claude-code",
       "kind": "billing",
       "url": "https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan",
-      "notes": "Re-verified 2026-06-28: the billing change originally planned for 2026-06-15 is still PAUSED. The page opens with a dated banner: 'Update June 15: We're pausing the changes to Claude Agent SDK usage described below. For now, nothing has changed: Claude Agent SDK, claude -p, and third-party app usage still draw from your subscription's usage limits.' Accounts using an API key continue on pay-as-you-go API billing. The original plan described separate monthly credits per plan tier (Pro $20, Max 5x $100, Max 20x $200, Team Standard $20, Team Premium $100, Enterprise $200) but this plan is paused and not in effect.",
+      "notes": "Re-verified 2026-06-29: the billing change originally planned for 2026-06-15 is still PAUSED. The page opens with a dated banner: 'Update June 15: We're pausing the changes to Claude Agent SDK usage described below. For now, nothing has changed: Claude Agent SDK, claude -p, and third-party app usage still draw from your subscription's usage limits.' Accounts using an API key continue on pay-as-you-go API billing. The original plan described separate monthly credits per plan tier (Pro $20, Max 5x $100, Max 20x $200, Team Standard $20, Team Premium $100, Enterprise $200) but this plan is paused and not in effect.",
       "claims": [
         "Agent SDK with Claude plan",
         "claude -p headless",
-        "2026-06-15 Agent SDK billing change still paused as of 2026-06-28",
+        "2026-06-15 Agent SDK billing change still paused as of 2026-06-29",
         "Agent SDK and claude -p currently draw from regular subscription usage limits same as interactive use",
         "API key accounts remain pay-as-you-go API billing",
         "original plan described separate monthly credits per plan tier but change is paused"

--- a/prompts/daily-official-doc-update.md
+++ b/prompts/daily-official-doc-update.md
@@ -79,7 +79,7 @@ do not cover as `not documented`.
 re-verified every run: which usage the Pro/Max subscription covers vs. what bills
 as API, whether a present `ANTHROPIC_API_KEY` switches Claude Code to API billing,
 and the status of the **2026-06-15** Agent SDK / `claude -p` plan-usage change.
-As of 2026-06-28 that change is **paused** (Agent SDK and `claude -p` still draw
+As of 2026-06-29 that change is **paused** (Agent SDK and `claude -p` still draw
 from the subscription usage limits, same as interactive use — no separate per-run
 credit). Confirm each run whether it is still paused, resumed, or cancelled, and
 keep the status + date current. This is a **time-sensitive status claim**: advance


### PR DESCRIPTION
Live re-verified the Claude Agent SDK / claude -p plan-usage billing status: the
official support page banner still reads "Update June 15: We're pausing the
changes..."; Agent SDK / claude -p still draw from subscription usage limits;
API-key accounts remain pay-as-you-go. Pro/Max page unchanged. Advanced the
time-sensitive billing stamps (cli-invocation.md, cloud-automation.md,
official-sources.json, daily prompt) 06-28 → 06-29.

No structural drift this run: Codex/Claude/Grok/Hermes/Cursor/GitHub + gajae-code
README re-verified, no material drift; yesterday's plugins-reference themes/channels
and headless bg-wait-cap (v2.1.182) facts re-confirmed present and accurate. The
gajae structural verified stamp (06-27) and Antigravity SPA render stamps (06-22)
left untouched. Antigravity SPA unverified this run (claude-in-chrome not
connected). check-official-sources.mjs --write-report passed (52 sources).
