### PR TITLE
fix(auto-merge-guard): merge worktree-safely (drop --delete-branch local checkout)

### DIFF
--- a/scripts/auto-merge-guard.sh
+++ b/scripts/auto-merge-guard.sh
@@ -36,5 +36,19 @@ if ! node scripts/check-official-sources.mjs --write-report; then
   exit 1
 fi
 
-gh pr merge "$PR" --squash --delete-branch
+# Merge and clean up WITHOUT touching any local branch or checkout.
+# `gh pr merge --delete-branch` switches local HEAD to the base branch (to delete
+# the merged local branch). That fails with "fatal: '<base>' is already used by
+# worktree ..." when the base branch is checked out in a sibling git worktree —
+# which is exactly how the daily routine runs (routine worktree + shared main
+# checkout). So merge without --delete-branch (no local branch ops) and delete the
+# remote branch explicitly (a remote-only ref delete that never switches HEAD).
+# Note: local `main` is intentionally NOT fast-forwarded here — the guard must not
+# touch a sibling worktree's checked-out branch; whoever owns that checkout pulls.
+head=$(gh pr view "$PR" --json headRefName -q '.headRefName')
+gh pr merge "$PR" --squash
+# Best-effort: the squash-merge already succeeded, so a failed branch delete
+# (e.g. already gone, or protected) must not flip the guard to a failure exit.
+git push origin --delete "$head" >/dev/null 2>&1 || \
+  echo "guard: PR #$PR merged, but remote branch '$head' delete was skipped/failed (non-fatal)" >&2
 echo "guard: PR #$PR merged (docs-only diff + source check passed)"


### PR DESCRIPTION
## What
The daily doc-refresh `auto-merge-guard.sh` squash-merges the refresh PR remotely, but then `gh pr merge --delete-branch` tries to switch local HEAD to `main` to delete the local branch. Because the routine runs in a sibling git worktree while `main` is checked out in the shared checkout, that switch fails with `fatal: 'main' is already used by worktree ...` — **after** the remote merge already succeeded.

Effects observed two days running (PRs #38, #39): the guard exited non-zero despite a successful merge, the remote branch was left undeleted, and local `main` was never fast-forwarded.

## Fix
- Merge **without** `--delete-branch` (no local branch operations).
- Delete the **remote** branch explicitly via `git push origin --delete` (remote-only; never switches local HEAD).
- Remote-branch delete is best-effort so it can't flip a successful merge to a failure exit.
- Local `main` is intentionally **not** fast-forwarded — the guard must not touch a sibling worktree's checked-out branch; whoever owns that checkout pulls.

## Scope / safety
- Code-only change to the post-merge cleanup path; docs-only gate + source-check behavior unchanged.
- `bash -n` passes.
- This is a **code** change, so it is opened for human review (the guard itself only auto-merges docs-only diffs).