### PR TITLE
fix(auto-merge-guard): delete remote branch explicitly to avoid worktree checkout-switch failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ package manifest, so the **git tag plus this file are the version record**
 (the official Claude SKILL.md frontmatter documents only `name` and
 `description`, so the version is intentionally not stamped there).
 
+## v1.22 — 2026-06-30
+
+Fix the auto-merge guard's post-merge branch cleanup for git-worktree layouts.
+
+### Fixed
+
+- **`auto-merge-guard.sh` no longer fails on `gh pr merge --delete-branch` in a
+  worktree checkout.** When the daily refresh runs from a linked git worktree (the
+  routine's own `aldegad/routine1` worktree) while `main` is checked out in the
+  shared canonical worktree, `--delete-branch`'s post-merge *local* step ("switch
+  off the just-deleted branch") aborts with `fatal: 'main' is already used by
+  worktree ...` — **after** the remote squash-merge has already succeeded, and it
+  leaves the remote branch stale on that failure. The guard now runs
+  `gh pr merge "$PR" --squash` and then deletes the remote ref explicitly
+  (`git push origin --delete <headRefName> || true`), which never touches a local
+  checkout. The routine worktree is left intact for reuse and the next run's
+  `git fetch --prune` clears the stale remote-tracking ref. The merge gate's
+  docs-only + source-check policy is unchanged; only the cleanup mechanics changed.
+
 ## v1.21 — 2026-06-30
 
 Daily refresh: billing re-verified live, still paused; freshness stamps advanced.

--- a/scripts/auto-merge-guard.sh
+++ b/scripts/auto-merge-guard.sh
@@ -36,5 +36,21 @@ if ! node scripts/check-official-sources.mjs --write-report; then
   exit 1
 fi
 
-gh pr merge "$PR" --squash --delete-branch
+gh pr merge "$PR" --squash
+
+# Remote-branch cleanup, done explicitly instead of via `gh pr merge --delete-branch`.
+# In a git-worktree layout that flag's post-merge LOCAL step ("switch off the deleted
+# branch") fails with `fatal: 'main' is already used by worktree ...` AFTER the remote
+# merge has already succeeded — and on that failure it also leaves the remote branch
+# stale. Deleting the remote ref directly never touches any local checkout, so the
+# routine worktree is left intact and the next run's `git fetch --prune` clears the
+# stale remote-tracking ref. The cleanup is best-effort and observable: a failed delete
+# logs a note (and the next prune clears it) but does not fail the gate — the merge
+# itself is already verified by the line above.
+HEAD_BRANCH=$(gh pr view "$PR" --json headRefName -q .headRefName 2>/dev/null || true)
+if [ -n "$HEAD_BRANCH" ]; then
+  git push origin --delete "$HEAD_BRANCH" \
+    || echo "guard: note — remote branch $HEAD_BRANCH not deleted (already gone or push declined); next 'git fetch --prune' clears the stale ref" >&2
+fi
+
 echo "guard: PR #$PR merged (docs-only diff + source check passed)"


### PR DESCRIPTION
gh pr merge --delete-branch's post-merge local step fails with 'main is already
used by worktree' in the routine's git-worktree layout (after the remote merge
already succeeded), and leaves the remote branch stale. Replace it with an
explicit, observable remote-ref delete that never touches a local checkout.
