### PR TITLE
feat(model-lineup): add Model Lineup category + docs/models/ folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ package manifest, so the **git tag plus this file are the version record**
 (the official Claude SKILL.md frontmatter documents only `name` and
 `description`, so the version is intentionally not stamped there).
 
+## v1.25 — 2026-07-02
+
+New **Model Lineup** category: track each runtime's current shipping model ids, reasoning/effort tiers, and retired models against the official vendor model pages, re-verified by the daily refresh.
+
+### Added
+
+- **`docs/models/` folder** — one file per runtime (`claude`, `codex`, `grok`,
+  `gemini-antigravity`, `cursor`, `hermes`, `kuma-studio`) plus a `README.md`
+  documenting the SSoT boundary, maintenance policy, and provenance-stamp rule.
+  Each file records current shipping model ids, reasoning/effort tiers, retired
+  models, its official source URL, and a `Last reviewed:` stamp. Seed lineup
+  (2026-07-02): Claude = Opus 4.8 / Sonnet 5 / Haiku 4.5 / Fable 5 current, Opus
+  4.7 + Sonnet 4.6 retired; Codex/Grok/others seeded from the Kuma catalog and
+  marked `unverified this run` pending official-page confirmation.
+- **Three `kind: "model-lineup"` sources** in `docs/official-sources.json`
+  (`anthropic-model-lineup` / `openai-codex-model-lineup` / `xai-grok-model-lineup`),
+  anchored on the official model pages (`docs.anthropic.com`,
+  `developers.openai.com/codex/models`, `docs.x.ai`) — all reachable (HTTP 200) in
+  the check run; no new `allowedHosts` needed.
+- **`guardCategory("model-lineup", "Model Lineup")`** in
+  `scripts/check-official-sources.mjs` so a future edit cannot silently drop the
+  category or its codex + claude-code anchors, with two covering tests in
+  `check-official-sources.test.mjs` (drop-entirely and missing-anchor).
+- **`## Model Lineup`** section in `SKILL.md` and a **MODEL LINEUP — do not skip
+  this category** paragraph in `prompts/daily-official-doc-update.md`, both stating
+  the SSoT boundary (owns current ids/tiers/retirement; links out to pricing =
+  `claude-api`, spawnable catalog = kuma-studio `team.json` downstream, naming =
+  Kuma vault) and the `unverified this run` discipline.
+
+### Boundary
+
+- `docs/models/` is a **vendor-truth record**; the Kuma Studio `team.json`
+  `modelCatalog` is a **downstream consumer** that syncs from it, never the
+  reverse. Pricing stays with the `claude-api` skill; naming/phonetic-gloss stays
+  with the Kuma vault. This category links to those, does not duplicate them.
+
 ## v1.24 — 2026-07-02
 
 Daily refresh: billing re-verified live, still paused; Antigravity SPA re-rendered; freshness stamps advanced.

--- a/SKILL.md
+++ b/SKILL.md
@@ -71,6 +71,16 @@ Same-platform resume (continue the *same* conversation on the *same* engine, by 
 - **Cross-engine moves** (resume one engine's session under a *different* engine) are a separate, harder problem and out of scope here — keep them off the same-platform path.
 - When a runtime does not document resume, record `not documented` and require live verification before shipping.
 
+## Model Lineup
+
+Which models each runtime **currently ships** — the exact ids a caller selects today, their reasoning/effort tiers, and which models the vendor has **retired** — drifts on its own cadence (a new frontier model or a retirement lands independently of any skill/hook/CLI change). The detailed, source-cited record lives in `docs/models/` (one file per runtime, each with a `Last reviewed:` stamp and its official URL); this is the short working model:
+
+- **Claude / Claude Code** — current: Opus 4.8 (`claude-opus-4-8`), Sonnet 5 (`claude-sonnet-5`), Haiku 4.5 (`claude-haiku-4-5`), Fable 5 (`claude-fable-5`). Retired: Opus 4.7 (`claude-opus-4-7` → 4.8) and Sonnet 4.6 (`claude-sonnet-4-6` → 5). Reasoning is extended thinking; the numeric `effort`/`ultracode` labels are a Claude Code caller-layer selector, not distinct vendor models.
+- **Codex** — seed ids `gpt-5.5` / `gpt-5.4-mini` / `gpt-5.3-codex-spark` with reasoning as `model_reasoning_effort` + `service_tier` config knobs; the exact set is `unverified this run` against `developers.openai.com/codex/models`.
+- **Grok / Gemini-Antigravity / Cursor / Hermes** — router- or provider-routed; ids seeded from downstream catalogs and `unverified this run` against each vendor page. Cursor and Hermes select **upstream** provider models rather than shipping their own.
+
+**SSoT boundary — this folder does not own everything model-shaped.** It owns *current shipping ids + tiers + retirement status*, verified against each vendor's official model page. It does **not** own: **pricing/limits** (the `claude-api` skill and vendor pricing pages), the **Kuma Studio spawnable catalog** (`packages/shared/team.json` `modelCatalog` — a *downstream consumer* that syncs from these lineups, never the reverse), or **naming/phonetic-gloss standards** (the Kuma vault `domains/model-frontier.md`). Link to those; do not duplicate. When a value cannot be confirmed against the official doc in a run, mark it `unverified this run` and leave it for the next daily pass — never substitute a guess or a non-vendor mirror.
+
 ## Project Instruction Files
 
 Do not assume every non-Claude runtime reads `AGENTS.md`. Use the officially documented project-instruction filename for the target runtime:

--- a/docs/models/README.md
+++ b/docs/models/README.md
@@ -1,0 +1,61 @@
+# Model Lineup
+
+This folder is the skill's record of **which models each tracked runtime
+currently ships** — the model ids a caller can actually select today, their
+reasoning / effort tiers, and which models the vendor has **retired**. The daily
+official-docs refresh re-verifies it against each vendor's own model
+documentation (`kind: "model-lineup"` sources in `docs/official-sources.json`).
+
+## What this folder owns
+
+- Per-runtime **current shipping model ids** (the exact strings a CLI/API caller
+  passes as the model).
+- Each model's **reasoning / effort tiers** where the runtime documents them
+  (e.g. Claude effort levels, Codex `model_reasoning_effort`).
+- **Retired / superseded** models — the id plus the model that replaced it — so a
+  stale reference is caught instead of silently spawning a dead model.
+- The **official source URL** each runtime's lineup is verified against, plus a
+  `Last reviewed:` stamp.
+
+## What this folder does NOT own (link, do not copy)
+
+- **Pricing / rate limits / token costs** — owned by the `claude-api` skill and
+  each vendor's pricing page. Reference, never duplicate.
+- **The Kuma Studio spawnable catalog** — `packages/shared/team.json`
+  (`modelCatalog`) in the kuma-studio repo. That is a **downstream consumer** that
+  syncs from these lineups; it is not the source of vendor truth. When a model is
+  retired here, the team.json catalog is updated separately (see the kuma-studio
+  repo), not the other way around.
+- **Naming conventions / Korean phonetic gloss / standard notation** — owned by
+  the Kuma vault (`domains/model-frontier.md`). This folder uses the vendor's
+  literal model id, not a house style.
+
+## Maintenance policy
+
+- **Current truth only.** State what ships today. Do not append the previous
+  lineup in the body — the change narrative goes in `CHANGELOG.md` with its git
+  tag. Replace a changed fact rather than stacking the old one beside it.
+- **Cite the runtime's own official doc.** Do not infer one runtime's lineup from
+  another. If the official docs do not document a model or tier, write
+  `not documented` / `unknown`.
+- **`unverified this run`.** If a value could not be confirmed against the
+  official doc during a refresh (URL 403/unreachable, JS-rendered SPA returning an
+  empty shell, or the model simply not yet documented), mark it
+  `unverified this run` and leave it for the next daily pass to confirm — never
+  substitute a guess or a non-vendor mirror.
+- **Provenance stamp.** Each runtime file carries a `Last reviewed:` date and the
+  official URL it was checked against. That stamp is the only dated line allowed
+  in the body. Advance it when the file is re-verified; a model lineup that reads
+  as months-old looks wrong even when still true.
+
+## Files
+
+| File | Runtime | Source of truth |
+|---|---|---|
+| `claude.md` | Claude / Claude Code | `docs.anthropic.com` models overview |
+| `codex.md` | OpenAI Codex | `developers.openai.com/codex/models` |
+| `grok.md` | Grok / xAI | `docs.x.ai` models |
+| `gemini-antigravity.md` | Google Antigravity CLI (`agy`) / Gemini | official Google docs |
+| `cursor.md` | Cursor CLI | `docs.cursor.com` |
+| `hermes.md` | Hermes Agent (Nous) | `hermes-agent.nousresearch.com` |
+| `kuma-studio.md` | Kuma Studio | downstream catalog note (points at team.json) |

--- a/docs/models/claude.md
+++ b/docs/models/claude.md
@@ -1,0 +1,36 @@
+# Claude / Claude Code — model lineup
+
+Official source: https://docs.anthropic.com/en/docs/about-claude/models/overview
+Last reviewed: 2026-07-02
+
+## Current shipping models
+
+| Family | Model id | Reasoning / effort | Notes |
+|---|---|---|---|
+| Claude Opus 4.8 | `claude-opus-4-8` | extended thinking; Claude Code exposes effort tiers (`high` / `medium` / `xhigh`, plus `max`) | Most capable tier. `[1m]` long-context variant selectable in Claude Code. |
+| Claude Sonnet 5 | `claude-sonnet-5` | extended thinking / effort | Balanced tier; supersedes Sonnet 4.6. |
+| Claude Haiku 4.5 | `claude-haiku-4-5` | fast tier | Low-latency / low-cost tier. |
+| Claude Fable 5 | `claude-fable-5` | effort tiers as above | Ships across effort tiers in Claude Code. |
+
+- The Claude 5 family, Opus 4.8, and Haiku 4.5 are the current generation.
+- Reasoning is delivered via **extended thinking**; the numeric `effort` /
+  `ultracode` labels are a **Claude Code / caller-layer** selector, not a distinct
+  vendor model — keep effort tiers described here as "as the CLI exposes them" and
+  do not present them as separate model ids.
+
+## Retired / superseded
+
+| Retired model | Replaced by | Notes |
+|---|---|---|
+| `claude-opus-4-7` (Claude Opus 4.7) | `claude-opus-4-8` | Fully removed from the Kuma Studio spawnable catalog 2026-07-02. |
+| `claude-sonnet-4-6` (Claude Sonnet 4.6) | `claude-sonnet-5` | Superseded by Sonnet 5. |
+
+## Boundaries
+
+- **Pricing / limits:** see the `claude-api` skill and Anthropic pricing docs — not
+  duplicated here.
+- **Spawnable catalog:** `packages/shared/team.json` in kuma-studio is the
+  downstream consumer that syncs these ids; it is not the vendor source of truth.
+- **Exact model id suffixes** (dated snapshots such as `-20251001`) are documented
+  in the Anthropic models overview; when a caller needs a pinned snapshot, cite the
+  official page rather than assuming a suffix here.

--- a/docs/models/codex.md
+++ b/docs/models/codex.md
@@ -1,0 +1,33 @@
+# OpenAI Codex — model lineup
+
+Official source: https://developers.openai.com/codex/models
+Last reviewed: 2026-07-02 (model ids seeded from the Kuma Studio spawnable
+catalog; **the exact set below is `unverified this run` against the official
+Codex models page** — the daily refresh must confirm ids and tiers against
+`developers.openai.com/codex/models`.)
+
+## Current shipping models (seed — verify against official page)
+
+| Model id | Reasoning / effort | Service tier | Notes |
+|---|---|---|---|
+| `gpt-5.5` | `model_reasoning_effort` = `medium` / `high` / `xhigh` | standard, plus `fast` (`service_tier=fast`) | Primary Codex model in the Kuma catalog. |
+| `gpt-5.4-mini` | `model_reasoning_effort` = `high` | `fast` | Smaller / cheaper tier. |
+| `gpt-5.3-codex-spark` | `high` | `fast` | Codex Spark low-latency tier. |
+
+- Codex exposes reasoning as `model_reasoning_effort` (a `-c` config value) and a
+  `service_tier` (e.g. `fast`), not as separate model ids — describe them as
+  config knobs on the model, not distinct models.
+- The **headless** launch is `codex exec` (see `docs/cli-invocation.md`); model
+  selection is `-m <model>` / a config profile.
+
+## Retired / superseded
+
+- `unverified this run` — the official page must confirm which prior gpt-5.x /
+  codex models are retired. Do not assert a retirement without the vendor doc.
+
+## Boundaries
+
+- **Pricing / rate limits:** OpenAI pricing docs — not duplicated here.
+- **Spawnable catalog:** kuma-studio `team.json` `modelCatalog` is the downstream
+  consumer; the ids above were seeded from it and must be re-confirmed against the
+  official Codex models page.

--- a/docs/models/cursor.md
+++ b/docs/models/cursor.md
@@ -1,0 +1,27 @@
+# Cursor CLI — model lineup
+
+Official source: https://docs.cursor.com/models
+Last reviewed: 2026-07-02 (**`unverified this run`** — Cursor routes to
+third-party frontier models rather than shipping its own; the concrete
+selectable set must be confirmed against `docs.cursor.com` by the daily refresh.)
+
+## Current model access (seed — verify against official docs)
+
+- Cursor CLI (`cursor-agent`) selects from **third-party frontier models**
+  (Anthropic Claude, OpenAI GPT, Google Gemini, xAI Grok families) rather than a
+  Cursor-owned model. There is no distinct "Cursor model id" to ship — the
+  selectable list mirrors whichever provider models Cursor currently exposes.
+- The exact model menu and any "auto" / default selection are
+  `unverified this run`; cite `docs.cursor.com` for the current list rather than
+  copying another runtime's ids.
+
+## Retired / superseded
+
+- `unverified this run` — track model availability changes from the Cursor docs.
+
+## Boundaries
+
+- **Pricing / limits:** Cursor pricing docs.
+- These are the **same upstream models** covered by `claude.md` / `codex.md` /
+  `grok.md` / `gemini-antigravity.md`; this file records only Cursor's access to
+  them, not a separate lineup.

--- a/docs/models/gemini-antigravity.md
+++ b/docs/models/gemini-antigravity.md
@@ -1,0 +1,33 @@
+# Google Antigravity CLI (`agy`) / Gemini — model lineup
+
+Official source: https://antigravity.google (JS-rendered SPA — a static fetch
+returns an empty shell; render dynamically before claiming a change) plus the
+Google Gemini model docs.
+Last reviewed: 2026-07-02 (**`unverified this run`** — Antigravity's site is a
+SPA and the Gemini model ids below are seeded from the Nous router catalog, not
+confirmed against an official Google model page this run.)
+
+## Current shipping models (seed — verify against official docs)
+
+| Model id (seed) | Notes |
+|---|---|
+| `gemini-3.1-pro` | Available via the Hermes/Nous router as `google/gemini-3.1-pro-preview`; confirm the native Gemini id, `-preview` status, and tier. |
+| `gemini-3.5-flash` | Router id `google/gemini-3.5-flash`; low-latency flash tier. |
+
+- **Antigravity CLI** (`agy`) is the Gemini CLI successor; Gemini CLI itself
+  stopped serving individual Pro/Ultra/free users as of **2026-06-18** (enterprise
+  / Google Cloud keeps it). Keep legacy Gemini references in past tense.
+- The Antigravity site is a **JS-rendered SPA**: treat a 200 with an empty shell
+  as `unverified this run` and render it dynamically before recording a model
+  change.
+
+## Retired / superseded
+
+- Gemini CLI (individual users) retired 2026-06-18, replaced by Antigravity CLI
+  (`agy`). Specific Gemini model retirements are `unverified this run`.
+
+## Boundaries
+
+- **Pricing / limits:** Google AI / Gemini pricing docs.
+- **Spawnable catalog:** the Gemini ids reach Kuma only through the Hermes/Nous
+  router, not a native Antigravity spawn entry.

--- a/docs/models/grok.md
+++ b/docs/models/grok.md
@@ -1,0 +1,29 @@
+# Grok / xAI — model lineup
+
+Official source: https://docs.x.ai/docs/models
+Last reviewed: 2026-07-02 (**`unverified this run` against the official xAI models
+page** — ids below are seeded from the Kuma Studio / Grok CLI catalog and must be
+confirmed against `docs.x.ai/docs/models` by the daily refresh.)
+
+## Current shipping models (seed — verify against official page)
+
+| Model id | Notes |
+|---|---|
+| `grok-build` | Grok CLI build model in the Kuma catalog; ships an Imagine skill (image/video gen). |
+| `grok-composer-2.5-fast` | Composer 2.5 fast tier. |
+| `grok-4.3` | Available via the Hermes/Nous router (`x-ai/grok-4.3`); confirm the native xAI id and tier against the official page. |
+
+- xAI documents its model list and reasoning options at `docs.x.ai`; the reasoning
+  / effort taxonomy is `unverified this run` and must be sourced from the official
+  page, not inferred from another runtime.
+
+## Retired / superseded
+
+- `unverified this run` — do not assert Grok model retirements without the vendor
+  doc.
+
+## Boundaries
+
+- **Pricing / limits:** xAI pricing docs.
+- **Spawnable catalog:** kuma-studio `team.json` (`grok-build`,
+  `grok-composer-2.5-fast`) is the downstream consumer.

--- a/docs/models/hermes.md
+++ b/docs/models/hermes.md
@@ -1,0 +1,37 @@
+# Hermes Agent (Nous Research) — model lineup
+
+Official source: https://hermes-agent.nousresearch.com
+Last reviewed: 2026-07-02 (**`unverified this run`** — the router model ids below
+are seeded from the Kuma Studio catalog; the daily refresh must confirm the
+current provider list and ids against the official Hermes docs.)
+
+## Current router models (seed — verify against official docs)
+
+Hermes runs as a **multi-provider router** (`--provider nous`): the model id is a
+`provider/model` path, not a Hermes-owned model. Seeded from the Kuma catalog:
+
+| Router model id | Upstream |
+|---|---|
+| `deepseek/deepseek-v4-pro` | DeepSeek V4 Pro |
+| `openai/gpt-5.5-pro` | OpenAI GPT-5.5 Pro |
+| `google/gemini-3.1-pro-preview` | Google Gemini 3.1 Pro (preview) |
+| `google/gemini-3.5-flash` | Google Gemini 3.5 Flash |
+| `qwen/qwen3.7-max` | Qwen 3.7 Max |
+| `moonshotai/kimi-k2.6` | Moonshot Kimi K2.6 |
+| `x-ai/grok-4.3` | xAI Grok 4.3 |
+
+- The reasoning / effort taxonomy is per-upstream and `not documented` at the
+  Hermes router layer beyond the provider's own; do not infer it.
+- Headless launch is `hermes chat -q` (see `docs/cli-invocation.md`); history is
+  in SQLite `~/.hermes/state.db` (see **Session Resume**).
+
+## Retired / superseded
+
+- `unverified this run` — the router list changes as providers rotate; confirm
+  additions/removals against the official Hermes docs each run.
+
+## Boundaries
+
+- **Pricing / limits:** per-provider via the Nous router; see Hermes docs.
+- **Spawnable catalog:** kuma-studio `team.json` `hermes-*` entries are the
+  downstream consumer of this router list.

--- a/docs/models/kuma-studio.md
+++ b/docs/models/kuma-studio.md
@@ -1,0 +1,40 @@
+# Kuma Studio — model lineup
+
+Official source: the Kuma Studio repo `packages/shared/team.json` (`modelCatalog`)
+— this is a **downstream consumer**, not a vendor. It syncs the ids that the
+vendor lineups (`claude.md`, `codex.md`, `grok.md`, `hermes.md`,
+`gemini-antigravity.md`) establish as current.
+Last reviewed: 2026-07-02
+
+## What Kuma Studio ships as spawnable
+
+Kuma Studio does **not** own or ship models. Its `team.json` `modelCatalog`
+exposes a per-tier selection of the upstream models above so a Studio member can
+be spawned on them (Claude / Codex / Grok / Hermes runtimes). When an upstream
+model is retired here, the catalog is edited in the kuma-studio repo — this file
+is not the source of that truth, it points at it.
+
+- **SSoT for the spawnable catalog:** `packages/shared/team.json` in kuma-studio
+  (a symlink target at `~/.kuma/team.json` for the runtime).
+- **Per-member model pin:** `~/.kuma/member-runtime-profiles.json` owns a member's
+  local spawn model (the `model` field), separate from the catalog.
+
+## Sync direction
+
+vendor official docs → this `docs/models/*` record → kuma-studio `team.json`
+(downstream). Never the reverse: do not treat team.json as evidence of what a
+vendor ships.
+
+## Recent catalog change
+
+- **2026-07-02:** Claude Opus 4.7 (`claude-opus-4-7`, 9 catalog entries) removed
+  and Sonnet 4.6 (`claude-sonnet-4-6`) bumped to Sonnet 5 (`claude-sonnet-5`) in
+  the kuma-studio catalog. Fable 5 was already present. See `claude.md` for the
+  vendor lineup; the change narrative lives in the kuma-studio repo history, not
+  here.
+
+## Boundaries
+
+- **Pricing / limits:** not tracked by Kuma Studio; see each vendor.
+- **Naming / phonetic gloss:** owned by the Kuma vault
+  (`domains/model-frontier.md`), not this folder.

--- a/docs/official-sources.json
+++ b/docs/official-sources.json
@@ -1167,6 +1167,49 @@
         "project instruction file loading not documented",
         "config ~/.gjc/config.yml and per-project .gjc/ state"
       ]
+    },
+    {
+      "id": "anthropic-model-lineup",
+      "agent": "claude-code",
+      "kind": "model-lineup",
+      "url": "https://docs.anthropic.com/en/docs/about-claude/models/overview",
+      "notes": "Current Claude model lineup (ids + reasoning). Mirror: docs/models/claude.md. As of 2026-07-02 current: Opus 4.8 (claude-opus-4-8), Sonnet 5 (claude-sonnet-5), Haiku 4.5 (claude-haiku-4-5), Fable 5 (claude-fable-5); retired: Opus 4.7 (claude-opus-4-7 → 4.8), Sonnet 4.6 (claude-sonnet-4-6 → 5).",
+      "claims": [
+        "claude-opus-4-8 current",
+        "claude-sonnet-5 current",
+        "claude-haiku-4-5 current",
+        "claude-fable-5 current",
+        "claude-opus-4-7 retired superseded by claude-opus-4-8",
+        "claude-sonnet-4-6 superseded by claude-sonnet-5"
+      ]
+    },
+    {
+      "id": "openai-codex-model-lineup",
+      "agent": "codex",
+      "kind": "model-lineup",
+      "url": "https://developers.openai.com/codex/models",
+      "notes": "Current Codex model lineup (ids + model_reasoning_effort / service_tier). Mirror: docs/models/codex.md. Seed ids gpt-5.5 / gpt-5.4-mini / gpt-5.3-codex-spark from the Kuma catalog are unverified this run against this page — the daily refresh must confirm the current set and any retirements here.",
+      "claims": [
+        "gpt-5.5 current",
+        "gpt-5.4-mini current",
+        "gpt-5.3-codex-spark current",
+        "reasoning via model_reasoning_effort and service_tier config knobs",
+        "retired models unverified this run"
+      ]
+    },
+    {
+      "id": "xai-grok-model-lineup",
+      "agent": "grok",
+      "kind": "model-lineup",
+      "url": "https://docs.x.ai/docs/models",
+      "notes": "Current Grok/xAI model lineup. Mirror: docs/models/grok.md. Seed ids grok-build / grok-composer-2.5-fast / grok-4.3 are unverified this run against this page; confirm native ids, tiers, and retirements each run.",
+      "claims": [
+        "grok-build current",
+        "grok-composer-2.5-fast current",
+        "grok-4.3 available via router",
+        "reasoning taxonomy unverified this run",
+        "retired models unverified this run"
+      ]
     }
   ]
 }

--- a/prompts/daily-official-doc-update.md
+++ b/prompts/daily-official-doc-update.md
@@ -91,6 +91,29 @@ both mirrors so they stay consistent: the **Billing caveat** note in
 `docs/cli-invocation.md` and the **"Why not a local cron"** block in
 `docs/cloud-automation.md`.
 
+**MODEL LINEUP — do not skip this category.** Every source in
+`docs/official-sources.json` with `"kind": "model-lineup"` MUST be fetched and
+re-verified every run. For each runtime confirm the **current shipping model ids**
+(the exact strings a caller passes), their **reasoning / effort tiers** where the
+vendor documents them, and which models are **retired / superseded** (id + its
+replacement). If the official docs added a model, changed a tier, or retired one,
+treat the **Model Lineup** baseline as drifted and update both mirrors so they
+stay consistent: the `## Model Lineup` section of `SKILL.md` and the matching
+per-runtime file under `docs/models/`. Cite the runtime's own official model page
+(`docs.anthropic.com` for Claude, `developers.openai.com/codex/models` for Codex,
+`docs.x.ai` for Grok, etc.); do not infer one runtime's lineup from another.
+`docs/models/` owns **current shipping ids + tiers + retirement status only** — it
+does NOT own pricing/limits (the `claude-api` skill), the Kuma Studio spawnable
+catalog (`team.json`, a downstream consumer that syncs from these lineups), or
+naming standards (the Kuma vault); link to those, do not duplicate. If a value
+cannot be confirmed against the official doc this run (403/unreachable, a
+JS-rendered SPA returning an empty shell, or simply not yet documented), record it
+as `unverified this run` and leave it for the next pass — never substitute a guess
+or a non-vendor mirror. The per-file `Last reviewed:` stamp is a
+**time-sensitive** provenance line: advance it to today on every successful
+re-verification (see the freshness-stamp rule under **IF THERE ARE NO CHANGES**),
+because a model lineup that reads as months-old looks wrong even when still true.
+
 **IF THERE ARE CHANGES:** make small, reviewable edits to the repo docs. Cite the
 official source URL in the docs or in the PR body. Run
 `node scripts/check-official-sources.mjs --write-report`. Do NOT push to `main`

--- a/scripts/check-official-sources.mjs
+++ b/scripts/check-official-sources.mjs
@@ -142,6 +142,7 @@ export function validateManifest(manifest) {
   }
   guardCategory("cli-invocation", "CLI Spawn And Headless Launch");
   guardCategory("session-resume", "Session Resume");
+  guardCategory("model-lineup", "Model Lineup");
 
   return failures;
 }

--- a/scripts/check-official-sources.test.mjs
+++ b/scripts/check-official-sources.test.mjs
@@ -50,6 +50,20 @@ function validManifest() {
         kind: "session-resume",
         url: "https://code.claude.com/docs/en/sessions",
         claims: ["Claude session resume source"]
+      },
+      {
+        id: "codex-model-lineup",
+        agent: "codex",
+        kind: "model-lineup",
+        url: "https://developers.openai.com/codex/models",
+        claims: ["Codex model lineup source"]
+      },
+      {
+        id: "claude-model-lineup",
+        agent: "claude-code",
+        kind: "model-lineup",
+        url: "https://code.claude.com/docs/en/models",
+        claims: ["Claude model lineup source"]
       }
     ]
   };
@@ -110,6 +124,30 @@ test("required baseline categories stay guarded", () => {
   assert.match(
     failures.join("\n"),
     /no source has kind=session-resume; the Session Resume baseline must stay covered/
+  );
+});
+
+test("model-lineup category stays guarded when dropped entirely", () => {
+  const manifest = validManifest();
+  manifest.sources = manifest.sources.filter((source) => source.kind !== "model-lineup");
+
+  const failures = validateManifest(manifest);
+
+  assert.match(
+    failures.join("\n"),
+    /no source has kind=model-lineup; the Model Lineup baseline must stay covered/
+  );
+});
+
+test("model-lineup category requires both codex and claude-code anchors", () => {
+  const manifest = validManifest();
+  manifest.sources = manifest.sources.filter((source) => source.id !== "claude-model-lineup");
+
+  const failures = validateManifest(manifest);
+
+  assert.match(
+    failures.join("\n"),
+    /missing kind=model-lineup source for claude-code/
   );
 });
 


### PR DESCRIPTION
## Summary

Adds a **Model Lineup** category so the daily official-docs refresh verifies each runtime's *current shipping model ids + reasoning/effort tiers + retired models* against the official vendor model pages — the drift that the prior categories (skills/hooks/plugins/project-instructions/cli-invocation/session-resume/billing) did not cover.

## What changed

- **`docs/models/`** — new folder: `README.md` (SSoT boundary, maintenance policy, provenance-stamp rule) + one file per runtime (`claude`, `codex`, `grok`, `gemini-antigravity`, `cursor`, `hermes`, `kuma-studio`). Seed (2026-07-02): Claude = Opus 4.8 / Sonnet 5 / Haiku 4.5 / Fable 5 **current**, Opus 4.7 + Sonnet 4.6 **retired**; Codex/Grok/others seeded from the Kuma catalog and marked `unverified this run` pending official-page confirmation.
- **`docs/official-sources.json`** — 3 `kind: "model-lineup"` sources (`anthropic-model-lineup`, `openai-codex-model-lineup`, `xai-grok-model-lineup`) anchored on the official model pages. All reachable (HTTP 200) in the check; no new `allowedHosts` needed.
- **`scripts/check-official-sources.mjs`** — `guardCategory("model-lineup", "Model Lineup")` (requires codex + claude-code anchors) + 2 covering tests in `check-official-sources.test.mjs`.
- **`SKILL.md`** — `## Model Lineup` section (303 lines, ≤500).
- **`prompts/daily-official-doc-update.md`** — MODEL LINEUP category paragraph.
- **`CHANGELOG.md`** — v1.25.

## SSoT boundary

`docs/models/` owns *current ids + tiers + retirement status* only. It does **not** own pricing/limits (the `claude-api` skill), the Kuma Studio spawnable catalog (`packages/shared/team.json` `modelCatalog` — a downstream consumer that syncs from these lineups, never the reverse), or naming/phonetic-gloss standards (the Kuma vault). Links to those, does not duplicate.

## Verification

- `node scripts/check-official-sources.mjs` → PASS (55 sources, SKILL.md 303 lines; 3 new model-lineup sources HTTP 200)
- `node --test scripts/check-official-sources.test.mjs` → 8/8 pass

## Landing

This PR touches **code** (`check-official-sources.mjs`), so `auto-merge-guard.sh` will decline (docs/prose-only gate) and leave it open. **Intended for human review — do not force-merge.**