### PR TITLE
aldegad/routine1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,14 +83,21 @@ carrying.
 ### Notes
 
 - **Grok Build was open-sourced (2026-07-14, Apache-2.0, `github.com/xai-org/grok-build`)
-  — but `docs.x.ai` does not mention it.** A full-corpus check of xAI's own
-  `llms.txt` (1.29 MB) returns **zero** hits for "open source", "Apache", or "MIT";
-  every `github.com` link in the corpus points to `xai-sdk-python`,
-  `xai-cookbook`, or `xai-proto`. Recording the OSS status therefore requires the
-  repo itself as a source — deferred pending an explicit policy call, since it is
-  a source-tier question, not drift. Note the repo also ships 24 official
-  user-guide docs, and this skill already has a "vendor source" evidence tier
-  (`completion-stack.md` source-verifies against `openai/codex`).
+  — recorded, with a deliberately narrow scope.** xAI's docs never say so: a
+  full-corpus check of their own `llms.txt` (1.29 MB) returns **zero** hits for
+  "open source", "Apache", or "MIT", and every `github.com` link in the corpus
+  points to `xai-sdk-python`, `xai-cookbook`, or `xai-proto`. The docs-only rule
+  therefore *structurally cannot* record this fact, so `xai-grok-build-repo` was
+  registered under a new `source-availability` kind and a new
+  `policy.vendorSourceRule` was added to name the exception — the manifest's own
+  `sourceRule` would otherwise contradict the source sitting under it.
+  **Scope guard:** the repo owns only licensing/source-availability;
+  `docs.x.ai` stays canonical for every behavior claim, so no claim gets two
+  owners. The repo's 24 bundled user-guide docs were **deliberately not
+  registered** for the same reason — `docs.x.ai` already covers that ground, and
+  registering them would split the SSoT. The precedent for a vendor-source tier
+  already existed (`completion-stack.md` source-verifies Codex goal internals
+  against `openai/codex`); this run just made the rule explicit.
 
 ## v1.35 — 2026-07-16
 

--- a/docs/cli-invocation.md
+++ b/docs/cli-invocation.md
@@ -169,6 +169,23 @@ Official (Google Developers Blog, posted 2026-05-19; antigravity.google docs):
   (JSONL); Claude/Cursor `--output-format json|stream-json`; Grok
   `--output-format json`. Hermes and Antigravity document **no** headless JSON
   output flag.
+- **Source availability — Grok Build is the one tracked vendor CLI whose source
+  is published.** SpaceXAI open-sourced the Grok Build harness and TUI on
+  2026-07-14 under **Apache-2.0** at `github.com/xai-org/grok-build`; external
+  contributions are not accepted and issues are disabled, so it is readable, not
+  participatory. Practical effect: behavior you cannot get a doc answer for can be
+  read from the implementation — but that is **implementation, not a vendor
+  contract**, so label any such finding `source-verified` with its path and expect
+  it to move without notice (`policy.vendorSourceRule`). Note the licence is
+  attested **only by the repo**: xAI's own docs never mention it (a full-corpus
+  check of `docs.x.ai/llms.txt` returns zero hits for "open source"/"Apache"/"MIT"),
+  which is why `xai-grok-build-repo` exists as a narrow `source-availability`
+  source while `docs.x.ai` stays canonical for every behavior claim. Every other
+  tracked vendor CLI (Codex, Claude Code, `agy`, `cursor-agent`, Hermes) ships as a
+  distributed binary with no published source — and for Antigravity specifically,
+  the transition blog does **not** state the OSS repo's licence, so no Apache-2.0
+  claim is made for it. (The Codex *goal internals* in `completion-stack.md` are
+  source-verified against `openai/codex` under the same rule.)
 - **Claude Code Agent SDK billing (status as of 2026-07-17):** The billing change planned for 2026-06-15 remains **paused** — `claude -p` and Agent SDK usage on subscription plans continues drawing from the same usage limits as interactive sessions. The separate monthly credit scheme is not active. For `ANTHROPIC_API_KEY` users billing remains pay-as-you-go. For scripted/CI runs against a subscription, authenticate with `claude setup-token` (a long-lived OAuth token, requires a subscription) rather than an API key, and pass `--output-format json` to capture `total_cost_usd` plus a per-model cost breakdown per invocation. Note that `--bare` skips OAuth/keychain, so it needs `ANTHROPIC_API_KEY` or an `apiKeyHelper` (via `--settings`) — i.e. bare mode implies API-key billing unless an `apiKeyHelper` is supplied. (Source: https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan, verified 2026-07-17.)
 - Session resume identifiers differ (UUID session id vs. human name vs.
   `--last` / `-1` vs. `--conversation <uuid>`). Store a resume handle in the form

--- a/docs/official-sources.json
+++ b/docs/official-sources.json
@@ -3,6 +3,7 @@
   "updated": "2026-07-17",
   "policy": {
     "sourceRule": "Use only official vendor documentation for compatibility claims. If the official docs do not document a capability, record not documented or unknown.",
+    "vendorSourceRule": "Narrow exception to sourceRule, for facts a vendor's docs structurally cannot attest — not a general licence to read code. A vendor-owned artifact (its public source repo) may anchor ONLY: (a) source availability and licence, and (b) implementation internals explicitly labelled source-verified with the file path, where no doc states them. It may never anchor a capability/compatibility claim that a vendor doc already covers — that claim keeps its doc owner, so the two never split. Source-verified facts are implementation, not a vendor contract: they can change without notice and must be re-verified like any other claim. Current holders: xai-grok-build-repo (kind source-availability; Grok Build is Apache-2.0 but docs.x.ai never says so) and docs/completion-stack.md (Codex /goal internals verified against openai/codex).",
     "nonVendorRule": "A small number of non-vendor runtimes (e.g. gajae-code, a community/MIT project) are tracked from their own project README rather than vendor docs. They must be explicitly flagged as community/non-vendor in the docs, held to the same not-documented discipline, and never presented as official vendor guarantees.",
     "mainBranchRule": "Daily automation must create a PR; it must not push directly to main.",
     "allowedHosts": [
@@ -491,6 +492,22 @@
         "GROK_HOOK_NAME",
         "GROK_SESSION_ID",
         "GROK_WORKSPACE_ROOT"
+      ]
+    },
+    {
+      "id": "xai-grok-build-repo",
+      "agent": "grok",
+      "kind": "source-availability",
+      "url": "https://github.com/xai-org/grok-build",
+      "notes": "Registered 2026-07-17. SCOPE IS DELIBERATELY NARROW — this source owns ONLY the source-availability/licensing fact, which no docs.x.ai page attests. It does NOT own behavior claims: docs.x.ai remains canonical for how Grok behaves (rules discovery, skills, plugins, hooks, headless, sessions, models), and this repo must not be cited for them, or the same claim would have two owners. Why it needs its own source at all: SpaceXAI open-sourced the Grok Build CLI on 2026-07-14 under Apache-2.0, but xAI's documentation never says so — a full-corpus check of xAI's own machine-readable export (docs.x.ai/llms.txt, 1.29 MB) returns ZERO hits for 'open source', 'open-source', 'Apache', 'MIT License', 'BSD', 'GPL', or 'self-host', and every github.com link in that corpus points to xai-sdk-python, xai-cookbook, or xai-proto — never to a CLI source repo. Every 'licen*' hit in the docs is about Grok Business seat licenses, not software licensing. So the docs-only discipline structurally cannot record this fact, and the vendor's own repo is the primary attestation. Precedent for a vendor-source tier already exists in this skill: docs/completion-stack.md source-verifies Codex goal internals against openai/codex. NOTE the repo also ships 24 official user-guide docs under crates/codegen/xai-grok-pager/docs/user-guide/ (skills, plugins, hooks, project-rules, headless-mode, sessions...). They are deliberately NOT registered: docs.x.ai covers the same ground and is canonical, so registering them would split the SSoT. Revisit only if docs.x.ai drops a category the repo still documents.",
+      "claims": [
+        "SpaceXAI's coding agent harness and TUI published at github.com/xai-org/grok-build",
+        "Apache License 2.0",
+        "repository created 2026-07-14",
+        "external contributions are not accepted",
+        "GitHub issues are disabled on the repository",
+        "ships official user-guide docs under crates/codegen/xai-grok-pager/docs/user-guide/ (not registered — docs.x.ai is canonical for behavior)",
+        "docs.x.ai makes no open-source, license, or source-availability claim about Grok Build (llms.txt full-corpus check, zero hits)"
       ]
     },
     {


### PR DESCRIPTION
- **docs: 2026-07-17 daily refresh — register Grok's missing project-instructions + cli-invocation sources; correct the AGENTS.md family and retire "tree semantics unknown"**
- **docs: record Grok Build's Apache-2.0 source availability via a narrow vendor-source exception**
